### PR TITLE
Document Image3d::data buffer size in IDL helpstring.

### DIFF
--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -47,14 +47,14 @@ struct ProbeInfo {
 
 typedef [
   uuid(74355329-DFEF-4BC0-9103-CF9579536FE3),
-  helpstring("3D image data struct.")]
+  helpstring("3D image data struct. Data buffer might not be packed.")]
 struct Image3d {
     [helpstring("time [seconds]")]                                            double          time;
     [helpstring("")]                                                          ImageFormat     format;
     [helpstring("resolution (width, height, planes)")]                        unsigned short  dims[3];
     [helpstring("distance between each row [bytes] (>= width*element_size)")] unsigned short  stride0;
     [helpstring("distance between each plane [bytes] (>= height*stride0)")]   unsigned short  stride1;
-    [helpstring("underlying 1D image buffer")]                                SAFEARRAY(byte) data;
+    [helpstring("underlying 1D image buffer (size >= planes*stride1)")]       SAFEARRAY(byte) data;
 } Image3d;
 
 


### PR DESCRIPTION
Should hopefully fix #5.
