### PR TITLE
Make ECG consistent with frame data

### DIFF
--- a/DummyLoader/Image3dSource.hpp
+++ b/DummyLoader/Image3dSource.hpp
@@ -60,7 +60,7 @@ public:
             trig_times.push_back(startTime + duration/2);
             trig_times.push_back(startTime + duration);
 
-            EcgSeriesObj ecg(startTime, startTime + duration, samples, trig_times); // 1 sec interval
+            EcgSeriesObj ecg(startTime, duration/N, samples, trig_times); 
             m_ecg = ecg;
         }
         {


### PR DESCRIPTION
Move ECG to start at the same time as the first frame, and fix bugs that prevented ECG from being computed correctly.
