### PR TITLE
Change color-map datatype to SAFEARRAY to make it automation compatible

### DIFF
--- a/DummyLoader/Image3dSource.hpp
+++ b/DummyLoader/Image3dSource.hpp
@@ -166,8 +166,16 @@ public:
         return S_OK;
     }
 
-    HRESULT STDMETHODCALLTYPE GetColorMap (/*[out]*/ unsigned int color_map[256]) {
-        memcpy(color_map, m_color_map.data(), sizeof(m_color_map));
+    HRESULT STDMETHODCALLTYPE GetColorMap (/*out*/ SAFEARRAY ** map) {
+        if (!map)
+            return E_INVALIDARG;
+        if (*map)
+            return E_INVALIDARG;
+
+        // copy to new buffer
+        CComSafeArray<unsigned int> color_map(static_cast<unsigned int>(m_color_map.size()));
+        memcpy(&color_map.GetAt(0), m_color_map.data(), sizeof(m_color_map));
+        *map = color_map.Detach(); // transfer ownership
         return S_OK;
     }
 

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -117,8 +117,8 @@ interface IImage3dSource : IUnknown {
     [helpstring("Get a bounding box encapsulating all image data. Can be used as intput to GetFrame to avoid cropping.")]
     HRESULT GetBoundingBox ([out,retval] Cart3dGeom * geom);
 
-    [helpstring("Retrieve color-map table for mapping image intensities to RGBx values.")]
-    HRESULT GetColorMap ([out,retval] unsigned int[256]);
+    [helpstring("Retrieve color-map table for mapping image intensities to RGBx values. Length is 256.")]
+    HRESULT GetColorMap ([out,retval] SAFEARRAY(unsigned int) * map);
 
     [helpstring("Get ECG data if available [optional]")]
     HRESULT GetECG ([out,retval] EcgSeries * ecg);

--- a/TestClient/Main.cpp
+++ b/TestClient/Main.cpp
@@ -8,6 +8,14 @@ void ParseSource (IImage3dSource & source) {
     unsigned int frame_count = 0;
     CHECK(source.GetFrameCount(&frame_count));
 
+    CComSafeArray<unsigned int> color_map;
+    {
+        SAFEARRAY * tmp = nullptr;
+        CHECK(source.GetColorMap(&tmp));
+        color_map.Attach(tmp);
+        tmp = nullptr;
+    }
+
     for (unsigned int frame = 0; frame < frame_count; ++frame) {
         unsigned short max_res[] = {128, 128, 128};
 


### PR DESCRIPTION
Makes it easier for client code in "managed" languages (Java/C#) and scripting languages (Python) to access the API.
