### PR TITLE
Change stride0 and stride1 from unsigned short to unsigned int

### DIFF
--- a/IImage3d_GuiClient/MainWindow.xaml.cs
+++ b/IImage3d_GuiClient/MainWindow.xaml.cs
@@ -266,8 +266,8 @@ namespace IImage3d_GuiClient
 
                 //get pixel dimensions, stride lengths, and adjusted image dimensions based on real space.
                 dimValues = imageData.dims;
-                stride0 = imageData.stride0;
-                stride1 = imageData.stride1;
+                stride0 = (int)imageData.stride0;
+                stride1 = (int)imageData.stride1;
                 //Verify that all dims and stride are greater than 1.
                 if (dimValues[0] <= 1 || dimValues[1] <= 1 || dimValues[2] <= 1 || stride0 <= 1 || stride1 <= 1)
                 {

--- a/Image3dAPI/IImage3d.hpp
+++ b/Image3dAPI/IImage3d.hpp
@@ -65,7 +65,7 @@ struct Image3dObj : public Image3d {
         data    = nullptr;
     }
 
-    Image3dObj (double _time, ImageFormat _format, unsigned short _dims[3], const byte * in_buf, unsigned short  _stride0, unsigned short  _stride1) {
+    Image3dObj (double _time, ImageFormat _format, unsigned short _dims[3], const byte * in_buf, unsigned int _stride0, unsigned int  _stride1) {
         time    = _time;
         format  = _format;
         dims[0] = _dims[0];

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -52,8 +52,8 @@ struct Image3d {
     [helpstring("time [seconds]")]                                            double          time;
     [helpstring("")]                                                          ImageFormat     format;
     [helpstring("resolution (width/columns, height/rows, planes)")]           unsigned short  dims[3];
-    [helpstring("distance between each row [bytes] (>= width*element_size)")] unsigned short  stride0;
-    [helpstring("distance between each plane [bytes] (>= height*stride0)")]   unsigned short  stride1;
+    [helpstring("distance between each row [bytes] (>= width*element_size)")] unsigned int    stride0;
+    [helpstring("distance between each plane [bytes] (>= height*stride0)")]   unsigned int    stride1;
     [helpstring("underlying 1D image buffer (size >= planes*stride1)")]       SAFEARRAY(byte) data;
 } Image3d;
 


### PR DESCRIPTION
Breaking change in API. Change stride0 and stride 1 from unsigned short to unsigned int. Unsigned short easily becomes too short for stride1.
