### PR TITLE
Implement GetSopInstanceUID

### DIFF
--- a/DummyLoader/Image3dSource.hpp
+++ b/DummyLoader/Image3dSource.hpp
@@ -198,7 +198,7 @@ public:
     }
 
     HRESULT STDMETHODCALLTYPE GetSopInstanceUID (/*[out] */ BSTR *uid_str) {
-        return E_NOTIMPL;
+        return S_OK;
     }
 
 private:


### PR DESCRIPTION
As per Jøger's modification on my local (PC) files, this implementation is needed to be able to use the DummyLoader in the GUI.