### PR TITLE
Make NuGet package compatible with .NET

### DIFF
--- a/Image3dAPI/Image3dAPI.vcxproj
+++ b/Image3dAPI/Image3dAPI.vcxproj
@@ -90,11 +90,11 @@
     <PostBuildEvent>
       <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
 :: Copy interface definitions to shared project dir
-xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1
 :: Copy type libraries to shared platform folder
-xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)" || exit /b 1
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b 1</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -114,11 +114,11 @@ xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
     <PostBuildEvent>
       <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
 :: Copy interface definitions to shared project dir
-xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1
 :: Copy type libraries to shared platform folder
-xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)" || exit /b 1
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b 1</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -142,11 +142,11 @@ xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
     <PostBuildEvent>
       <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
 :: Copy interface definitions to shared project dir
-xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1
 :: Copy type libraries to shared platform folder
-xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)" || exit /b 1
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b 1</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -170,11 +170,11 @@ xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
     <PostBuildEvent>
       <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
 :: Copy interface definitions to shared project dir
-xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1
 :: Copy type libraries to shared platform folder
-xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)" || exit /b 1
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b 1</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Image3dAPI/Image3dAPI.vcxproj
+++ b/Image3dAPI/Image3dAPI.vcxproj
@@ -85,13 +85,16 @@
     <Midl>
       <OutputDirectory>$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
-      <TypeLibraryName>$(ProjectName).tlb</TypeLibraryName>
+      <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>xcopy /Y /D "$(IntDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-TlbImp.exe /machine:x86 "$(IntDir)$(TargetName).tlb" /out:$(SolutionDir)$(Platform)\$(TargetName).dll
+      <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+:: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"</Command>
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+:: Copy type libraries to shared platform folder
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -106,13 +109,16 @@ xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"</Command>
     <Midl>
       <OutputDirectory>$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
-      <TypeLibraryName>$(ProjectName).tlb</TypeLibraryName>
+      <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>xcopy /Y /D "$(IntDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-TlbImp.exe /machine:x64 "$(IntDir)$(TargetName).tlb" /out:$(SolutionDir)$(Platform)\$(TargetName).dll
+      <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+:: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"</Command>
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+:: Copy type libraries to shared platform folder
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -131,13 +137,16 @@ xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"</Command>
     <Midl>
       <OutputDirectory>$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
-      <TypeLibraryName>$(ProjectName).tlb</TypeLibraryName>
+      <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>xcopy /Y /D "$(IntDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-TlbImp.exe /machine:x86 "$(IntDir)$(TargetName).tlb" /out:$(SolutionDir)$(Platform)\$(TargetName).dll
+      <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+:: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"</Command>
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+:: Copy type libraries to shared platform folder
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -156,13 +165,16 @@ xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"</Command>
     <Midl>
       <OutputDirectory>$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
-      <TypeLibraryName>$(ProjectName).tlb</TypeLibraryName>
+      <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>xcopy /Y /D "$(IntDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
-TlbImp.exe /machine:x64 "$(IntDir)$(TargetName).tlb" /out:$(SolutionDir)$(Platform)\$(TargetName).dll
+      <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+:: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)"
-xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"</Command>
+xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)"
+:: Copy type libraries to shared platform folder
+xcopy /Y /D "$(OutDir)$(TargetName).tlb"  "$(SolutionDir)$(Platform)"
+xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/PackagingGE/Image3dAPI.net.targets
+++ b/PackagingGE/Image3dAPI.net.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- .NET/C# project config -->
+  <Target Name="InjectReference" BeforeTargets="ResolveAssemblyReferences">
+    <ItemGroup Condition="'$(Platform)' == 'Win32' or '$(Platform)' == 'x86'">
+      <Reference Include="Image3dAPI">
+        <HintPath>$(MSBuildThisFileDirectory)..\native\lib\Win32\Image3dAPI.dll</HintPath>
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </Reference>
+    </ItemGroup>
+    <ItemGroup Condition="'$(Platform)' == 'x64'">
+      <Reference Include="Image3dAPI">
+        <HintPath>$(MSBuildThisFileDirectory)..\native\lib\x64\Image3dAPI.dll</HintPath>
+        <EmbedInteropTypes>true</EmbedInteropTypes>
+      </Reference>
+    </ItemGroup>
+  </Target>
+</Project>

--- a/PackagingGE/Image3dAPI.nuspec
+++ b/PackagingGE/Image3dAPI.nuspec
@@ -32,11 +32,11 @@
         <file src="../Image3dAPI/IImage3d_p.c"   target="build/native/include/Image3dAPI/" />
         
         <!-- COM type libraries -->
-        <file src="../x64/Image3dAPI.tlb"        target="build/native/lib/x64/" />
-        <file src="../Win32/Image3dAPI.tlb"      target="build/native/lib/Win32/" />
+        <file src="../x64/Release/Image3dAPI.tlb"   target="build/native/lib/x64/" />
+        <file src="../Win32/Release/Image3dAPI.tlb" target="build/native/lib/Win32/" />
         <!-- .NET type libraries -->
-        <file src="../x64/Image3dAPI.dll"        target="build/native/lib/x64/" />
-        <file src="../Win32/Image3dAPI.dll"      target="build/native/lib/Win32/" />
+        <file src="../x64/Release/Image3dAPI.dll"   target="build/native/lib/x64/" />
+        <file src="../Win32/Release/Image3dAPI.dll" target="build/native/lib/Win32/" />
 
         <!-- documentation files -->
         <file src="../changelog.txt"             target="build/native/docs/" />

--- a/PackagingGE/Image3dAPI.nuspec
+++ b/PackagingGE/Image3dAPI.nuspec
@@ -20,7 +20,8 @@
     </metadata>
 
     <files>
-        <file src="Image3dAPI.targets" target="build/native/" />
+        <file src="Image3dAPI.targets"     target="build/native/" />
+        <file src="Image3dAPI.net.targets" target="build/net/Image3dAPI.targets" />
  
         <!-- support headers -->
         <file src="../Image3dAPI/ComSupport.hpp" target="build/native/include/Image3dAPI/" />


### PR DESCRIPTION
Add separate .targets file for .NET projects.

This significantly eases the process of using AppAPI in .NET/C# projects. All that is needed is to add the nuget package to the project, and everything is configured automatically.