### PR TITLE
API: DICOM-based ProbeType enum

### DIFF
--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -3,7 +3,7 @@
 
 
 Image3dSource::Image3dSource() {
-    m_probe.type = PROBE_THORAX;
+    m_probe.type = PROBE_External;
     m_probe.name = L"4V";
 
     // One second loop starting at t = 10

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -25,11 +25,15 @@ enum ImageFormat {
 typedef [
   v1_enum, // 32bit enum size
   uuid(8157DC93-DBC4-4BEC-922C-B197237CCF34),
-  helpstring("Probe type enum (extended upon demand).")]
+  helpstring("Probe type enum."
+             "Values taken from http://dicom.nema.org/medical/Dicom/2017b/output/chtml/part16/sect_CID_12035.html")]
 enum ProbeType {
-    PROBE_UNKNOWN   = 0,
-    PROBE_THORAX    = 1, ///< transthoracic probe (for imaging between ribs)
-    PROBE_ESOPHAGUS = 2  ///< transesophageal probe
+    PROBE_UNKNOWN         = 0,
+    PROBE_External        = 125261,
+    PROBE_Transesophageal = 125262,
+    PROBE_Endovaginal     = 125263,
+    PROBE_Endorectal      = 125264,
+    PROBE_Intravascular   = 125265,
 } ProbeType;
 
 cpp_quote("")


### PR DESCRIPTION
Change the `ProbeType` enum to match IDs from the DICOM standard: http://dicom.nema.org/medical/Dicom/2017b/output/chtml/part16/sect_CID_12035.html

Note that there's no “transthoracic” probe in the enum any more. Not sure if this can become a problem(?). One suggestion from WH is to use "anatomic modifiers": http://dicom.nema.org/medical/Dicom/2017b/output/chtml/part16/chapter_B.html


This **will trigger an API change**, since it changes the binary encoding of the probes.