### PR TITLE
Introduce API version checking

### DIFF
--- a/DummyLoader/GenRgsFiles.py
+++ b/DummyLoader/GenRgsFiles.py
@@ -22,18 +22,20 @@ text = """HKCR
 				val ThreadingModel = s 'THREAD-MODEL'
 			}
 			TypeLib = s '{TYPE-LIB}'
-			Version = s '1.0'
+			Version = s 'VERSION_MAJOR.VERSION_MINOR'
 		}
 	}
 }
 """
 
-def GenRgsFiles(progname, typelib, classes, threadmodel, concat_filename=None):
+def GenRgsFiles(progname, typelib, version, classes, threadmodel, concat_filename=None):
     all_rgs_content = ''
     for cls in classes:
         content = text
         content = content.replace('PROG-NAME', progname)
         content = content.replace('TYPE-LIB', typelib)
+        content = content.replace('VERSION_MAJOR', str(version[0]))
+        content = content.replace('VERSION_MINOR', str(version[1]))
         content = content.replace('THREAD-MODEL', threadmodel)
         content = content.replace('CLASS-NAME', cls[0])
         content = content.replace('CLASS-GUID', cls[1])
@@ -86,7 +88,17 @@ def ParseIdl (filename):
     
     return libname, typelib, classes
 
+def ParseImage3dAPIVersion (filename):
+    with open(filename, 'r') as f:
+        for line in f:
+            if "IMAGE3DAPI_VERSION_MAJOR =" in line:
+                major = int(line.split()[-1][:-1])
+            elif "IMAGE3DAPI_VERSION_MINOR =" in line:
+                minor = int(line.split()[-1][:-1])
+    return [major,minor]
+
 
 if __name__ == "__main__":
     libname, typelib, classes = ParseIdl('DummyLoader.idl')
-    GenRgsFiles(libname, typelib, classes, 'Both')
+    version = ParseImage3dAPIVersion("../Image3dAPI/IImage3d.idl")
+    GenRgsFiles(libname, typelib, version, classes, 'Both')

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -12,6 +12,17 @@ Design goals:
 /* Interfaces and data structures for exchanging image data. */
 import "oaidl.idl";
 
+
+typedef [
+  v1_enum, // 32bit enum size
+  uuid(39B49534-475A-474B-B91D-17BCA2062A40),
+  helpstring("Image3dAPI version.")]
+enum Image3dAPIVersion {
+    IMAGE3DAPI_VERSION_MAJOR = 1,
+    IMAGE3DAPI_VERSION_MINOR = 1,
+} Image3dAPIVersion;
+
+
 typedef [
   v1_enum, // 32bit enum size
   uuid(A45D637B-0D4A-4797-9949-2039D963C41C),

--- a/Image3dAPI/IImage3dTypeLibraryGenerator.idl
+++ b/Image3dAPI/IImage3dTypeLibraryGenerator.idl
@@ -8,13 +8,14 @@ import "IImage3d.idl";
 
 
 [
-	uuid(3ff1aab8-f3d8-33d4-825d-00104b3646c0),
-	helpstring("Interface to generate IImage3dAPI.tlb .")
+    uuid(3ff1aab8-f3d8-33d4-825d-00104b3646c0),
+    helpstring("Interface to generate IImage3dAPI.tlb .")
 ]
 library Image3dlib
 {
-	importlib("stdole32.tlb");
-	importlib("stdole2.tlb");
+    importlib("stdole32.tlb");
+    importlib("stdole2.tlb");
 
-	interface IImage3dFileLoader;
+    enum      Image3dAPIVersion;
+    interface IImage3dFileLoader;
 };

--- a/Image3dAPI/Image3dAPI.vcxproj
+++ b/Image3dAPI/Image3dAPI.vcxproj
@@ -183,6 +183,7 @@ xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ComSupport.hpp" />
+    <ClInclude Include="VersionCheck.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Image3dAPI/Image3dAPI.vcxproj.filters
+++ b/Image3dAPI/Image3dAPI.vcxproj.filters
@@ -6,5 +6,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ComSupport.hpp" />
+    <ClInclude Include="VersionCheck.hpp" />
   </ItemGroup>
 </Project>

--- a/Image3dAPI/VersionCheck.hpp
+++ b/Image3dAPI/VersionCheck.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <string>
+#include "ComSupport.hpp"
+
+
+/** Compare the version of a COM class against the current Image3dAPI version.
+    NOTE: Not compatible with reg-free COM, since the COM class version is not included in the manifest. */
+static HRESULT CheckImage3dAPIVersion (CLSID clsid) {
+    // build registry path")
+    CComBSTR reg_path(L"CLSID\\");
+    reg_path.Append(clsid);
+    reg_path.Append(L"\\Version");
+
+    // extract COM class version
+    CRegKey cls_reg;
+    if (cls_reg.Open(HKEY_CLASSES_ROOT, reg_path, KEY_READ) != ERROR_SUCCESS)
+        return E_NOT_SET;
+    ULONG    ver_str_len = 0;
+    if (cls_reg.QueryStringValue(nullptr, nullptr, &ver_str_len) != ERROR_SUCCESS)
+        return E_NOT_SET;
+    std::wstring ver_str(ver_str_len, L'\0');
+    if (cls_reg.QueryStringValue(nullptr, const_cast<wchar_t*>(ver_str.data()), &ver_str_len) != ERROR_SUCCESS)
+        return E_NOT_SET;
+    ver_str.resize(ver_str_len-1); // remove extra zero-termination
+
+    // compare against current Image3dAPI version
+    std::wstring cur_ver = std::to_wstring(Image3dAPIVersion::IMAGE3DAPI_VERSION_MAJOR)
+        +L"."+std::to_wstring(Image3dAPIVersion::IMAGE3DAPI_VERSION_MINOR);
+    if (ver_str == cur_ver)
+        return S_OK;
+    else
+        return E_INVALIDARG; // version mismatch
+}

--- a/PackagingGE/Image3dAPI.nuspec
+++ b/PackagingGE/Image3dAPI.nuspec
@@ -24,7 +24,8 @@
         <file src="Image3dAPI.net.targets" target="build/net/Image3dAPI.targets" />
  
         <!-- support headers -->
-        <file src="../Image3dAPI/ComSupport.hpp" target="build/native/include/Image3dAPI/" />
+        <file src="../Image3dAPI/ComSupport.hpp"   target="build/native/include/Image3dAPI/" />
+        <file src="../Image3dAPI/VersionCheck.hpp" target="build/native/include/Image3dAPI/" />
         
         <!-- interface definitions -->
         <file src="../Image3dAPI/IImage3d.idl"   target="build/native/include/Image3dAPI/" />

--- a/TestClient/Main.cpp
+++ b/TestClient/Main.cpp
@@ -1,5 +1,6 @@
 #include "../Image3dAPI/ComSupport.hpp"
 #include "../Image3dAPI/IImage3d.h"
+#include "../Image3dAPI/VersionCheck.hpp"
 
 
 void ParseSource (IImage3dSource & source) {
@@ -30,8 +31,15 @@ void ParseSource (IImage3dSource & source) {
 int main () {
     ComInitialize com(COINIT_MULTITHREADED);
 
+    CComBSTR progid(L"DummyLoader.Image3dFileLoader");
+    CLSID clsid = {};
+    CHECK(CLSIDFromProgID(progid, &clsid));
+
+    // verify that loader library is compatible
+    //CHECK(CheckImage3dAPIVersion(clsid)); // disabled, since it's not compatible with reg-free COM
+
     CComPtr<IImage3dFileLoader> loader;
-    CHECK(loader.CoCreateInstance(L"DummyLoader.Image3dFileLoader"));
+    CHECK(loader.CoCreateInstance(clsid));
 
     {
         // load file

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -35,6 +35,15 @@ namespace TestViewer
                 }
             }
 
+            // API version compatibility check
+            RegistryKey ver_key = Registry.ClassesRoot.OpenSubKey("CLSID\\{"+comType.GUID+"}\\Version");
+            string ver_str = (string)ver_key.GetValue("");
+            string cur_ver = string.Format("{0}.{1}", (int)Image3dAPIVersion.IMAGE3DAPI_VERSION_MAJOR, (int)Image3dAPIVersion.IMAGE3DAPI_VERSION_MINOR);
+            if (ver_str != cur_ver) {
+                MessageBox.Show(string.Format("Incompatible loader version. Loader uses version {0}, while the current version is {1}.", ver_str, cur_ver));
+                return;
+            }
+
             m_loader = (IImage3dFileLoader)Activator.CreateInstance(comType);
 
             this.FileOpenBtn.IsEnabled = true;


### PR DESCRIPTION
The recent https://github.com/MedicalUltrasound/Image3dAPI/pull/66 introduced an API change which will trigger the need for versioning of Image3dAPI. I'm planning to create a new Image3dAPI 1.1 release, but first want to add some safeguards against accidental mixups of incompatible loader vs. host implementations.

Summary of changes:
* Introduce Image3dAPIVersion enum to expose versioning as part of the API.
* New CheckImage3dAPIVersion function to simplify API version compatibility checking.
* Version the DummyLoader COM class in registry based on the API version in use.
* TestViewer: Check API version for compatibility before opening loader.
* TestClient: Add checking of loader version (disabled due to reg-free COM usage).