### PR TITLE
Use NuGet.exe from %PATH% instead of hardcoded file-path

### DIFF
--- a/PackagingGE/PackagePublishNuget.bat
+++ b/PackagingGE/PackagePublishNuget.bat
@@ -14,5 +14,5 @@ IF %ERRORLEVEL% NEQ 0 exit /B 1
 :: Publish artifact
 if NOT DEFINED NUGET_REPO exit /B 0
 :: Use timeout not dividable by 60 as work-around for https://nuget.codeplex.com/workitem/3917
-%LOCALAPPDATA%\NuGet\NuGet.exe push *.nupkg -Source %NUGET_REPO% -Timeout 1201
+NuGet.exe push *.nupkg -Source %NUGET_REPO% -Timeout 1201
 IF %ERRORLEVEL% NEQ 0 exit /B 1


### PR DESCRIPTION
Done to become consistent with doc in https://github.com/MedicalUltrasound/Image3dAPI/blob/master/PackagingGE/BuildNuGet.bat