### PR TITLE
DummyLoader: Quadratic checker-board squares

### DIFF
--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -39,14 +39,14 @@ Image3dSource::Image3dSource() {
     {
         // geometry          X     Y    Z
         Cart3dGeom geom = { -0.1f,-0.075f,  0,     // origin
-            0.2f, 0,       0,     // dir1
+            0.20f,0,       0,     // dir1
             0,    0.15f,   0,     // dir2
-            0,    0,       0.1f };// dir2
+            0,    0,       0.10f};// dir2
         m_geom = geom;
     }
     {
         // checker board image data
-        unsigned short dims[] = { 12, 14, 16 };
+        unsigned short dims[] = { 20, 15, 10 }; // matches length of dir1, dir2 & dir3, so that the image squares become quadratic
         std::vector<byte> img_buf(dims[0] * dims[1] * dims[2]);
         for (size_t f = 0; f < numFrames; ++f) {
             for (unsigned int z = 0; z < dims[2]; ++z) {


### PR DESCRIPTION
Adjust resolution of underlying checker-board image, so that the checker board squares become perfectly quadratic. Intended to ease investigation of aspect-ratio issues.

Before this PR:
![image](https://user-images.githubusercontent.com/2671400/43316219-e3d8b812-9198-11e8-94dd-bfb7c3048b79.png)
After applying this PR:
![image](https://user-images.githubusercontent.com/2671400/43316215-df9192e2-9198-11e8-8e88-d698f469c365.png)

Notice that the image slices are not shown in the same scale. That is a separate issues in TestViewer that should be handled separately.