### PR TITLE
DummyLoader: Additional bounds checking for negative indices

### DIFF
--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -148,6 +148,10 @@ static vec3f CoordToPos (Cart3dGeom geom, const vec3f xyz) {
 
 
 static unsigned char SampleVoxel (const Image3d & frame, const vec3f pos) {
+    // out-of-bounds checking
+    if ((pos.x < 0) || (pos.y < 0) || (pos.z < 0))
+        return 0; // black outside image volume
+
     auto x = static_cast<unsigned int>(frame.dims[0] * pos.x);
     auto y = static_cast<unsigned int>(frame.dims[1] * pos.y);
     auto z = static_cast<unsigned int>(frame.dims[2] * pos.z);


### PR DESCRIPTION
The existing unsigned integer bounds checking was failing for indices between -0.5 and 0.0, causing mirroring of the image data.

## Before/after comparison
Modifications to MainWindow::DrawImages to make the problem visible:
bbox.origin_x = -0.15f;
bbox.origin_y = -0.1f;

Before this PR:
![image](https://user-images.githubusercontent.com/2671400/43514365-5c57cae0-9580-11e8-90c2-8a6cd3f3ef5b.png)

After applying this PR:
![image](https://user-images.githubusercontent.com/2671400/43514257-1778dd92-9580-11e8-8fa4-660f8fd18f4d.png)
