### PR TITLE
TestViewer: Display image slices in same scale

### DIFF
--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -109,9 +109,9 @@ namespace TestViewer
         {
             Debug.Assert(m_source != null);
 
-            // retrieve image volume
-            const ushort HORIZONTAL_RES = 128;
-            const ushort VERTICAL_RES = 128;
+            // retrieve image slices
+            const ushort HORIZONTAL_RES = 256;
+            const ushort VERTICAL_RES = 256;
 
             Cart3dGeom bbox = m_source.GetBoundingBox();
             if (Math.Abs(bbox.dir3_y) > Math.Abs(bbox.dir2_y)){

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -167,9 +167,9 @@ namespace TestViewer
 
             uint[] color_map = m_source.GetColorMap();
 
-            ImageXY.Source = scaleBitmap(GenerateBitmap(imageXY, color_map), VecLen(bboxXY, 1), VecLen(bboxXY, 2));
-            ImageXZ.Source = scaleBitmap(GenerateBitmap(imageXZ, color_map), VecLen(bboxXZ, 1), VecLen(bboxXZ, 2));
-            ImageYZ.Source = scaleBitmap(GenerateBitmap(imageYZ, color_map), VecLen(bboxYZ, 1), VecLen(bboxYZ, 2));
+            ImageXY.Source = GenerateBitmap(imageXY, color_map);
+            ImageXZ.Source = GenerateBitmap(imageXZ, color_map);
+            ImageYZ.Source = GenerateBitmap(imageYZ, color_map);
         }
 
         private WriteableBitmap GenerateBitmap(Image3d image, uint[] color_map)
@@ -203,21 +203,6 @@ namespace TestViewer
             pixel[2] = channels[2]; // blue
             // discard alpha channel
         }
-
-        //Convert to TransformedBitmap to incorporate correct aspect ratio.
-        private static TransformedBitmap scaleBitmap(WriteableBitmap bitmap, double width, double height)
-        {
-            double widthFactor = 1;
-            double heightFactor = 1;
-
-            if (width > height)
-                widthFactor = width / height;
-            else
-                heightFactor = height / width;
-
-            return new TransformedBitmap(bitmap, new ScaleTransform(widthFactor, heightFactor));
-        }
-
 
         static void SwapVals(ref float v1, ref float v2)
         {


### PR DESCRIPTION
Modify TestViewer, so that all image slices are shown in the same scale on screen. Done by extending the bounding-box, so that all axes gets the same length

Before applying this PR: (notice the Y-Z checker rectangles are larger than the others)
![image](https://user-images.githubusercontent.com/2671400/43519616-7511ce54-9590-11e8-89b3-f03c7d941cd8.png)
After applying this PR:
![image](https://user-images.githubusercontent.com/2671400/43519605-67a36912-9590-11e8-842e-aa899263e7ec.png)
