### PR TITLE
API: Extend IImage3dFileLoader interface with  IsHighPerfMode method

### DIFF
--- a/DummyLoader/Image3dFileLoader.cpp
+++ b/DummyLoader/Image3dFileLoader.cpp
@@ -12,6 +12,14 @@ HRESULT Image3dFileLoader::LoadFile(BSTR file_name, /*out*/BSTR *error_message) 
     return S_OK; // no operation
 }
 
+HRESULT Image3dFileLoader::IsHighPerfMode(BOOL * high_perf) {
+    if (!high_perf)
+        return E_INVALIDARG;
+
+    *high_perf = true; // always CPU-based implementation
+    return S_OK;
+}
+
 HRESULT Image3dFileLoader::GetImageSource(/*out*/IImage3dSource **img_src) {
     if (!img_src)
         return E_INVALIDARG;

--- a/DummyLoader/Image3dFileLoader.hpp
+++ b/DummyLoader/Image3dFileLoader.hpp
@@ -21,6 +21,8 @@ public:
 
     HRESULT STDMETHODCALLTYPE LoadFile(BSTR file_name, /*out*/BSTR *error_message) override;
 
+    HRESULT STDMETHODCALLTYPE IsHighPerfMode(BOOL * high_perf) override;
+
     HRESULT STDMETHODCALLTYPE GetImageSource(/*out*/IImage3dSource **img_src) override;
 
     DECLARE_REGISTRY_RESOURCEID(IDR_Image3dFileLoader)

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -315,5 +315,11 @@ interface IImage3dFileLoader : IUnknown {
                 "The function shall return quickly with an informative error message (for debugging) in case of failure.")]
     HRESULT LoadFile ([in] BSTR file_name, [out, retval] BSTR * error_message);
 
+    [helpstring("Query if loader is operating in high-performance mode or not. This typically means GPU accelerated.\n"
+                "A output value false implies a lower performance CPU fallback implementation.\n"
+                "CPU-only loaders shall always return true.\n"
+                "Note that this method might return E_NOT_SET until a file have been loaded.")]
+    HRESULT IsHighPerfMode ([out,retval] BOOL * high_perf);
+
     HRESULT GetImageSource ([out,retval] IImage3dSource ** img_src);
 };


### PR DESCRIPTION
Proposal for enabling run-time query if the loader is operating in high-perf (GPU) vs. lower-perf (CPU) mode. (issue https://github.com/MedicalUltrasound/Image3dAPI/issues/92).