### PR TITLE
API: Add enum for signaling loader failures

### DIFF
--- a/DummyLoader/Image3dFileLoader.cpp
+++ b/DummyLoader/Image3dFileLoader.cpp
@@ -8,7 +8,12 @@ Image3dFileLoader::~Image3dFileLoader() {
 }
 
 
-HRESULT Image3dFileLoader::LoadFile(BSTR file_name, /*out*/BSTR *error_message) {
+HRESULT Image3dFileLoader::LoadFile(BSTR file_name, /*out*/Image3dError *err_type, /*out*/BSTR *err_msg) {
+    if (!err_type || !err_msg)
+        return E_INVALIDARG;
+
+    *err_type = Image3d_SUCCESS;
+    *err_msg  = CComBSTR().Detach();
     return S_OK; // no operation
 }
 

--- a/DummyLoader/Image3dFileLoader.hpp
+++ b/DummyLoader/Image3dFileLoader.hpp
@@ -19,7 +19,7 @@ public:
 
     /*NOT virtual*/ ~Image3dFileLoader();
 
-    HRESULT STDMETHODCALLTYPE LoadFile(BSTR file_name, /*out*/BSTR *error_message) override;
+    HRESULT STDMETHODCALLTYPE LoadFile(BSTR file_name, /*out*/Image3dError *err_type, /*out*/BSTR *err_msg) override;
 
     HRESULT STDMETHODCALLTYPE GetImageSource(/*out*/IImage3dSource **img_src) override;
 

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -300,7 +300,7 @@ interface IImage3dSource : IUnknown {
     HRESULT GetProbeInfo ([out,retval] ProbeInfo * probe);
 
     [helpstring("Get per-file DICOM UID string (to be matched against corresponding file)")]
-    HRESULT GetSopInstanceUID ([out,retval] BSTR * uid_str);
+    HRESULT GetSopInstanceUID ([out,string,retval] BSTR * uid_str);
 };
 
 
@@ -312,8 +312,8 @@ interface IImage3dSource : IUnknown {
 interface IImage3dFileLoader : IUnknown {
     [helpstring("Load proprietary image file.\n"
                 "The file might already by opened elsewhere, so no exclusive locks can be taken.\n"
-                "The function shall return quickly with an informative error message (for debugging) in case of failure.")]
-    HRESULT LoadFile ([in] BSTR file_name, [out, retval] BSTR * error_message);
+                "The function shall return quickly with informative error message (for debugging) in case of failure.")]
+    HRESULT LoadFile ([in,string] BSTR file_name, [out,string,retval] BSTR * error_message);
 
     HRESULT GetImageSource ([out,retval] IImage3dSource ** img_src);
 };

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -304,6 +304,18 @@ interface IImage3dSource : IUnknown {
 };
 
 
+typedef [
+    v1_enum, // 32bit enum size
+    helpstring("Image3dAPI error codes.")]
+enum Image3dError {
+    Image3d_SUCCESS              = 0,
+    Image3d_ACCESS_FAILURE       = 1, ///< file missing, inaccessible or locked
+    Image3d_VALIDATION_FAILURE   = 2, ///< file corrupt or does not contain required vendor tags
+    Image3d_NOT_YET_SUPPORTED    = 3, ///< the loader is too old to read the file and need to be updated
+    Image3d_SUPPORT_DISCONTINUED = 4, ///< the loader no longer support the file version
+    } Image3dError;
+
+
 [ object,
   oleautomation, // use "automation" marshaler (oleaut32.dll)
   uuid(CD30759B-EB38-4469-9CA5-4DF75737A31B),
@@ -312,8 +324,8 @@ interface IImage3dSource : IUnknown {
 interface IImage3dFileLoader : IUnknown {
     [helpstring("Load proprietary image file.\n"
                 "The file might already by opened elsewhere, so no exclusive locks can be taken.\n"
-                "The function shall return quickly with informative error message (for debugging) in case of failure.")]
-    HRESULT LoadFile ([in,string] BSTR file_name, [out,string,retval] BSTR * error_message);
+                "The function shall return quickly with error type and diagnostic message (in english) in case of failure.")]
+    HRESULT LoadFile ([in,string] BSTR file_name, [out] Image3dError * error_type, [out,string] BSTR * error_msg);
 
     HRESULT GetImageSource ([out,retval] IImage3dSource ** img_src);
 };

--- a/RegFreeTest/Main.cpp
+++ b/RegFreeTest/Main.cpp
@@ -45,8 +45,9 @@ int main () {
     {
         // load file
         CComBSTR filename = L"dummy.dcm";
-        CComBSTR error;
-        CHECK(loader->LoadFile(filename, &error));
+        Image3dError err_type = {};
+        CComBSTR err_msg;
+        CHECK(loader->LoadFile(filename, &err_type, &err_msg));
     }
 
     CComPtr<IImage3dSource> source;

--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -45,8 +45,9 @@ int main () {
     {
         // load file
         CComBSTR filename = L"dummy.dcm";
-        CComBSTR error;
-        CHECK(loader->LoadFile(filename, &error));
+        Image3dError err_type = {};
+        CComBSTR err_msg;
+        CHECK(loader->LoadFile(filename, &err_type, &err_msg));
     }
 
     CComPtr<IImage3dSource> source;

--- a/TestPython/TestPython.py
+++ b/TestPython/TestPython.py
@@ -46,7 +46,7 @@ if __name__=="__main__":
     loader = loader.QueryInterface(Image3dAPI.IImage3dFileLoader)
 
     # load file
-    loader.LoadFile("dummy.dcm")
+    err_type, err_msg = loader.LoadFile("dummy.dcm")
     source = loader.GetImageSource()
 
     # retrieve probe info

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -87,10 +87,30 @@ namespace TestViewer
         {
             Debug.Assert(m_loader != null);
 
-            string loader_error = m_loader.LoadFile(FileName.Text);
-            if ((loader_error != null) && (loader_error.Length > 0))
+            Image3dError err_type;
+            string err_msg;
+            m_loader.LoadFile(FileName.Text, out err_type, out err_msg);
+            if ((err_type != Image3dError.Image3d_SUCCESS))
             {
-                MessageBox.Show(loader_error);
+                string message;
+                switch (err_type) {
+                    case Image3dError.Image3d_ACCESS_FAILURE:
+                        message = "Unable to open the file. The file might be missing or locked.";
+                        break;
+                    case Image3dError.Image3d_VALIDATION_FAILURE:
+                        message = "Unsupported file. Probably due to unsupported vendor or modality.";
+                        break;
+                    case Image3dError.Image3d_NOT_YET_SUPPORTED:
+                        message = "The loader is too old to parse the file.";
+                        break;
+                    case Image3dError.Image3d_SUPPORT_DISCONTINUED:
+                        message = "The the file version is no longer supported (pre-DICOM format?).";
+                        break;
+                    default:
+                        message = "Unknown error";
+                        break;
+                }
+                MessageBox.Show(message+": "+err_msg);
                 return;
             }
             m_source = m_loader.GetImageSource();


### PR DESCRIPTION
API change proposal. Intended  to ease client-side error handling. It will in particular enable vendor-specific error messages and enable translation of the messages.

Fixes https://github.com/MedicalUltrasound/Image3dAPI/issues/97.

The enum can be extended with more values on demand.