### PR TITLE
TestViewer: Implement simple ECG display

### DIFF
--- a/TestViewer/MainWindow.xaml
+++ b/TestViewer/MainWindow.xaml
@@ -59,6 +59,9 @@
             
             <Image x:Name="ImageYZ" Grid.Column="0" Grid.Row="1"/>
             <Label TextBlock.Foreground="DimGray"  Grid.Column="0" Grid.Row="1">Y-Z plane</Label>
+
+            <Path x:Name="ECG" Grid.Column="1" Grid.Row="1"/>
+            <Label TextBlock.Foreground="DimGray"  Grid.Column="1" Grid.Row="1">ECG</Label>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
The ECG trace is auto-scaled to fit in the bottom-right quadrant together with the image slices. A vertical line annotates the current frame.

I've never used the .NET drawing APIs before, so the implementation might not adhere to best practices. Please let me know if you have suggestions for improvement opportunities.

Screenshots:
![image](https://user-images.githubusercontent.com/2671400/44944142-df3eb900-add1-11e8-893f-4967729c8d8b.png)
![image](https://user-images.githubusercontent.com/2671400/44944146-ec5ba800-add1-11e8-9f23-369090fbc23d.png)
