### PR TITLE
Misc debugging improvements

### DIFF
--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -11,7 +11,7 @@ Image3dSource::Image3dSource() {
     m_probe.name = L"4V";
 
     // One second loop starting at t = 10
-    const size_t numFrames = 60;
+    const size_t numFrames = 25;
     const double duration = 1.0; // Seconds
     const double startTime = 10.0;
 

--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -13,7 +13,6 @@ Image3dSource::Image3dSource() {
     // One second loop starting at t = 10
     const size_t numFrames = 60;
     const double duration = 1.0; // Seconds
-    const double fps = duration / numFrames;
     const double startTime = 10.0;
 
     {
@@ -80,7 +79,7 @@ Image3dSource::Image3dSource() {
 
             Image3d tmp;
             {
-                tmp.time = f * fps + startTime;
+                tmp.time = f*(duration/numFrames) + startTime;
                 tmp.format = FORMAT_U8;
                 for (size_t i = 0; i < 3; ++i)
                     tmp.dims[i] = dims[i];

--- a/TestClient/Main.cpp
+++ b/TestClient/Main.cpp
@@ -19,7 +19,7 @@ void ParseSource (IImage3dSource & source) {
     }
 
     for (unsigned int frame = 0; frame < frame_count; ++frame) {
-        unsigned short max_res[] = {128, 128, 128};
+        unsigned short max_res[] = {64, 64, 64};
 
         // retrieve frame data
         Image3d data;

--- a/TestPython/TestPython.py
+++ b/TestPython/TestPython.py
@@ -73,11 +73,12 @@ if __name__=="__main__":
     frame_count = source.GetFrameCount()
     for i in range(frame_count):
         max_res = np.ctypeslib.as_ctypes(np.array([64, 64, 64], dtype=np.ushort))
-        frame = source.GetFrame(0, bbox, max_res)
+        frame = source.GetFrame(i, bbox, max_res)
         
-        print("Frame time: "+str(frame.time))
-        print("Frame format: "+str(frame.format))
-        print("Frame dims: ("+str(frame.dims[0])+", "+str(frame.dims[1])+", "+str(frame.dims[2])+")")
+        print("Frame metadata:")
+        print("  time:   "+str(frame.time))
+        print("  format: "+str(frame.format))
+        print("  dims:  ("+str(frame.dims[0])+", "+str(frame.dims[1])+", "+str(frame.dims[2])+")")
 
         data = FrameTo3dArray(frame)
-        print("Frame data shape: "+str(data.shape))
+        print("  shape: "+str(data.shape))

--- a/TestPython/TestPython.py
+++ b/TestPython/TestPython.py
@@ -72,7 +72,7 @@ if __name__=="__main__":
 
     frame_count = source.GetFrameCount()
     for i in range(frame_count):
-        max_res = np.ctypeslib.as_ctypes(np.array([128, 128, 128], dtype=np.ushort))
+        max_res = np.ctypeslib.as_ctypes(np.array([64, 64, 64], dtype=np.ushort))
         frame = source.GetFrame(0, bbox, max_res)
         
         print("Frame time: "+str(frame.time))


### PR DESCRIPTION
Running of the C++ & Python test code in "debug" mode is currently quite slow. This PR aims to speed things up a bit by reducing the frame count and image volume sizes.

Changes to ease debugging:
* Reduce DummyLoader frame count from 60 to 25.
* Request smaller image volumes in test code.
* Fix incorrect frame index in python script

There are no API changes in this PR.