### PR TITLE
API extension to query loaders for supported (manufacturer,model) pairs

### DIFF
--- a/DummyLoader/Image3dFileLoader.cpp
+++ b/DummyLoader/Image3dFileLoader.cpp
@@ -7,6 +7,28 @@ Image3dFileLoader::Image3dFileLoader() {
 Image3dFileLoader::~Image3dFileLoader() {
 }
 
+HRESULT Image3dFileLoader::GetSupportedManufacturerModels(SAFEARRAY ** _manufacturer, SAFEARRAY ** _model) {
+    if (!_manufacturer || !_model)
+        return E_INVALIDARG;
+
+    CComSafeArray<BSTR> manufacturer((ULONG)0), model((ULONG)0);
+    // 1st pair
+    manufacturer.Add(L"Dummy medical systems");
+    model.Add(L"Super scanner *"); // matches "Super scanner 1", "Super scanner 2" etc.
+    
+    // 2nd pair
+    manufacturer.Add(L"Dummy healthcare");
+    model.Add(L"Some scanner 1");
+
+    // 3rd pair
+    manufacturer.Add(L"Dummy healthcare");
+    model.Add(L"Some scanner 2");
+
+    *_manufacturer = manufacturer.Detach();
+    *_model = model.Detach();
+    return S_OK;
+}
+
 
 HRESULT Image3dFileLoader::LoadFile(BSTR file_name, /*out*/BSTR *error_message) {
     return S_OK; // no operation

--- a/DummyLoader/Image3dFileLoader.hpp
+++ b/DummyLoader/Image3dFileLoader.hpp
@@ -19,6 +19,8 @@ public:
 
     /*NOT virtual*/ ~Image3dFileLoader();
 
+    HRESULT STDMETHODCALLTYPE GetSupportedManufacturerModels(SAFEARRAY **, SAFEARRAY **) override;
+
     HRESULT STDMETHODCALLTYPE LoadFile(BSTR file_name, /*out*/BSTR *error_message) override;
 
     HRESULT STDMETHODCALLTYPE GetImageSource(/*out*/IImage3dSource **img_src) override;

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -310,6 +310,11 @@ interface IImage3dSource : IUnknown {
   helpstring("Factory for loading 3D image data from a file.\n"
              "Implementors are responsible for also providing details on relevant DICOM tags that indicate that the loader might support the file.")]
 interface IImage3dFileLoader : IUnknown {
+    [helpstring("Return a list of (manufacturer,model) pairs for datasets supported by the loader. Both arrays shall have equal length.\n"
+                "Manufacturer corresponds to DICOM tag (0008,0070)\n"
+                "Manufacturer's Model Name corresponds to DICOM tag (0008,1090). The string might contain '*' as wildcard character.")]
+    HRESULT GetSupportedManufacturerModels ([out] SAFEARRAY(BSTR) * manufacturer, [out] SAFEARRAY(BSTR) * model);
+
     [helpstring("Load proprietary image file.\n"
                 "The file might already by opened elsewhere, so no exclusive locks can be taken.\n"
                 "The function shall return quickly with an informative error message (for debugging) in case of failure.")]

--- a/RegFreeTest/Main.cpp
+++ b/RegFreeTest/Main.cpp
@@ -42,6 +42,17 @@ int main () {
     CComPtr<IImage3dFileLoader> loader;
     CHECK(loader.CoCreateInstance(clsid));
 
+    // get list of supported (manufacturer,model) pairs
+    CComSafeArray<BSTR> manufacturer, model;
+    {
+        SAFEARRAY * ptr1 = nullptr;
+        SAFEARRAY * ptr2 = nullptr;
+        CHECK(loader->GetSupportedManufacturerModels(&ptr1, &ptr2));
+        manufacturer.Attach(ptr1);
+        model.Attach(ptr2);
+    }
+    assert(manufacturer.GetCount() == model.GetCount());
+
     {
         // load file
         CComBSTR filename = L"dummy.dcm";

--- a/TestPython/TestPython.py
+++ b/TestPython/TestPython.py
@@ -45,6 +45,10 @@ if __name__=="__main__":
     loader = comtypes.client.CreateObject("DummyLoader.Image3dFileLoader")
     loader = loader.QueryInterface(Image3dAPI.IImage3dFileLoader)
 
+    # get supported (manufacturer,model) pairs
+    manufacturer, model = loader.GetSupportedManufacturerModels()
+    assert(len(manufacturer) == len(model))
+
     # load file
     loader.LoadFile("dummy.dcm")
     source = loader.GetImageSource()


### PR DESCRIPTION
API proposal to address https://github.com/MedicalUltrasound/Image3dAPI/issues/90.

Done to enable integrators to determine which loader to use, based on the content of the following DICOM tags:
* (0008,0070) Manufacturer
* (0008,1090) Manufacturer's Model Name


### Example implementation
The GE cardiac loader will probably return something similar to:
```
{{“GE Vingmed Ultrasound”,“Vivid E95”},
 {“GE Vingmed Ultrasound”,“Vivid E90”},
 {“GE Vingmed Ultrasound”,“Vivid S70N”},
 {“GE Vingmed Ultrasound”,“Vivid E9”},
 {“GE Vingmed Ultrasound”,“Vivid 7”}}
```