### PR TITLE
API: Switch to DICOM coordinates

### DIFF
--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -40,11 +40,11 @@ Image3dSource::Image3dSource() {
             m_color_map[i] = R8G8B8A8(static_cast<unsigned char>(i), static_cast<unsigned char>(i), static_cast<unsigned char>(i), 0xFF);
     }
     {
-        // geometry          X     Y    Z
-        Cart3dGeom geom = { -0.1f,-0.075f,  0,     // origin
-            0.20f,0,       0,     // dir1
-            0,    0.15f,   0,     // dir2
-            0,    0,       0.10f};// dir2
+        // geometry          X     Y       Z
+        Cart3dGeom geom = { -0.1f, 0,     -0.075f,// origin
+                             0.20f,0,      0,     // dir1 (width)
+                             0,    0.10f,  0,     // dir2 (depth)
+                             0,    0,      0.15f};// dir3 (elevation)
         m_geom = geom;
     }
     {
@@ -69,9 +69,9 @@ Image3dSource::Image3dSource() {
             }
 
             // special grayscale value for plane closest to probe
-            for (unsigned int y = 0; y < dims[1]; ++y) {
+            for (unsigned int z = 0; z < dims[2]; ++z) {
                 for (unsigned int x = 0; x < dims[0]; ++x) {
-                    unsigned int z = 0;
+                    unsigned int y = 0;
                     byte & out_sample = img_buf[x + y*dims[0] + z*dims[0] * dims[1]];
                     out_sample = PROBE_PLANE;
                 }

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -161,8 +161,9 @@ cpp_quote("#endif")
 
 
 typedef [
-  helpstring("Cartesian 3D image geometry description. All units are in meter [m] and the axes shall be orthogonal.\n"
-             "Coordinates are relative to the tip of the probe, with origin at the center of the aperture. The X- & Y-axes follow the 1st and 2nd probe aperture axes, and the Z-axis points into the imaged body (right-hand rule).")]
+  helpstring("3D image geometry description that matches C.8.X.2.1.2 'Transducer Frame of Reference' in DICOM Enhanced Ultrasound (sup 43)\n"
+             "All units are in meter [m] with orthogonal axes forming a right-handed coordinate system.\n"
+             "Coordinates are relative to the tip of the transducer, with origin at the center of the aperture. The X- & Z-axes follow the 1st and 2nd aperture axes, and the Y-axis point into the imaged body.")]
 struct Cart3dGeom {
     // coordinates are not arrays to avoid "warning MIDL2492: structure containing array of float/double might not be marshalled correctly when using type library marshalling"
     float origin_x; ///< coordinate of 1st sample

--- a/TestViewer/MainWindow.xaml
+++ b/TestViewer/MainWindow.xaml
@@ -57,8 +57,8 @@
             <Image x:Name="ImageXZ" Grid.Column="1" Grid.Row="0"/>
             <Label TextBlock.Foreground="DimGray" Grid.Column="1" Grid.Row="0">X-Z plane</Label>
             
-            <Image x:Name="ImageYZ" Grid.Column="0" Grid.Row="1"/>
-            <Label TextBlock.Foreground="DimGray"  Grid.Column="0" Grid.Row="1">Y-Z plane</Label>
+            <Image x:Name="ImageZY" Grid.Column="0" Grid.Row="1"/>
+            <Label TextBlock.Foreground="DimGray"  Grid.Column="0" Grid.Row="1">Z-Y plane</Label>
 
             <Path x:Name="ECG" Grid.Column="1" Grid.Row="1"/>
             <Label TextBlock.Foreground="DimGray"  Grid.Column="1" Grid.Row="1">ECG</Label>

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace TestViewer
 
             ImageXY.Source = null;
             ImageXZ.Source = null;
-            ImageYZ.Source = null;
+            ImageZY.Source = null;
             ECG.Data = null;
         }
 
@@ -218,21 +218,21 @@ namespace TestViewer
             bboxXZ.dir3_z = 0;
             Image3d imageXZ = m_source.GetFrame(frame, bboxXZ, new ushort[] { HORIZONTAL_RES, VERTICAL_RES, 1 });
 
-            // get YZ plane (assumes 2nd axis is "Y" and 3rd is "Z")
-            Cart3dGeom bboxYZ = bbox;
-            bboxYZ.origin_x = bboxYZ.origin_x + bboxYZ.dir1_x / 2;
-            bboxYZ.origin_y = bboxYZ.origin_y + bboxYZ.dir1_y / 2;
-            bboxYZ.origin_z = bboxYZ.origin_z + bboxYZ.dir1_z / 2;
-            bboxYZ.dir1_x = bboxYZ.dir2_x;
-            bboxYZ.dir1_y = bboxYZ.dir2_y;
-            bboxYZ.dir1_z = bboxYZ.dir2_z;
-            bboxYZ.dir2_x = bboxYZ.dir3_x;
-            bboxYZ.dir2_y = bboxYZ.dir3_y;
-            bboxYZ.dir2_z = bboxYZ.dir3_z;
-            bboxYZ.dir3_x = 0; 
-            bboxYZ.dir3_y = 0;
-            bboxYZ.dir3_z = 0;
-            Image3d imageYZ = m_source.GetFrame(frame, bboxYZ, new ushort[] { HORIZONTAL_RES, VERTICAL_RES, 1 });
+            // get ZY plane (assumes 2nd axis is "Y" and 3rd is "Z")
+            Cart3dGeom bboxZY = bbox;
+            bboxZY.origin_x = bbox.origin_x + bbox.dir1_x / 2;
+            bboxZY.origin_y = bbox.origin_y + bbox.dir1_y / 2;
+            bboxZY.origin_z = bbox.origin_z + bbox.dir1_z / 2;
+            bboxZY.dir1_x = bbox.dir3_x;
+            bboxZY.dir1_y = bbox.dir3_y;
+            bboxZY.dir1_z = bbox.dir3_z;
+            bboxZY.dir2_x = bbox.dir2_x;
+            bboxZY.dir2_y = bbox.dir2_y;
+            bboxZY.dir2_z = bbox.dir2_z;
+            bboxZY.dir3_x = 0;
+            bboxZY.dir3_y = 0;
+            bboxZY.dir3_z = 0;
+            Image3d imageZY = m_source.GetFrame(frame, bboxZY, new ushort[] { HORIZONTAL_RES, VERTICAL_RES, 1 });
 
             FrameTime.Text = "Frame time: " + imageXY.time;
 
@@ -240,7 +240,7 @@ namespace TestViewer
 
             ImageXY.Source = GenerateBitmap(imageXY, color_map);
             ImageXZ.Source = GenerateBitmap(imageXZ, color_map);
-            ImageYZ.Source = GenerateBitmap(imageYZ, color_map);
+            ImageZY.Source = GenerateBitmap(imageZY, color_map);
         }
 
         private WriteableBitmap GenerateBitmap(Image3d image, uint[] color_map)


### PR DESCRIPTION
Proposal to modify the coordinate system to match C.8.X.2.1.2 'Transducer Frame of Reference' in DICOM Enhanced Ultrasound (sup 43). Fixes https://github.com/MedicalUltrasound/Image3dAPI/issues/88.
![image](https://user-images.githubusercontent.com/2671400/45485743-f75ef280-b758-11e8-9e5c-80462ec7bd29.png)

DummyLoader and TestViewer are updated to deliver the "same" images in the new coordinate system.


### TestViewer screenshots
Before:
![image](https://user-images.githubusercontent.com/2671400/45485782-1fe6ec80-b759-11e8-9f86-ac48c745a7a5.png)

After applying PR:
![image](https://user-images.githubusercontent.com/2671400/45485816-3725da00-b759-11e8-98fe-0fd0921bc286.png)
Note that the Y-Z slice is flipped to Z-Y to maintain orientation. Also, the images shown in the X-Y and X-Z slices are swapped.