### PR TITLE
API extension to query loaders for supported (manufacturer,model) pairs

### DIFF
--- a/DummyLoader/GenRgsFiles.py
+++ b/DummyLoader/GenRgsFiles.py
@@ -24,6 +24,12 @@ text = """HKCR
 			}
 			TypeLib = s '{TYPE-LIB}'
 			Version = s 'VERSION_MAJOR.VERSION_MINOR'
+
+			SupportedManufacturerModels
+			{
+				val 'Dummy medical systems' = s 'Super scanner *'
+				val 'Dummy healthcare'      = s 'Some scanner 1;Some scanner 2'
+			}
 		}
 	}
 

--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -35,6 +35,8 @@ int main () {
     CLSID clsid = {};
     CHECK(CLSIDFromProgID(progid, &clsid));
 
+    auto list = SupportedManufacturerModels::ReadList(clsid);
+
     // verify that loader library is compatible
     CHECK(CheckImage3dAPIVersion(clsid));
 


### PR DESCRIPTION
Alternative API proposal to address #90 that stores the manufacturer/model information in the registry.

Done to enable integrators to determine which loader to use **without having to instantiate them**. Based on matching the content of the following DICOM tags:
* (0008,0070) Manufacturer              - exact match
* (0008,1090) Manufacturer's Model Name - exact or '*'/wildcard match

Example registry content:
![image](https://user-images.githubusercontent.com/2671400/45550487-41180d80-b82b-11e8-876d-255f6d5d8247.png)
