### PR TITLE
Harden TestViewer to deal with two different modes of ECG failure

### DIFF
--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -133,6 +133,11 @@ namespace TestViewer
             EcgSeries ecg;
             try {
                 ecg = m_source.GetECG();
+
+                if (ecg.samples.Length == 0) {
+                    ECG.Data = null; // ECG not available
+                    return;
+                }
             } catch (Exception) {
                 ECG.Data = null; // ECG not available
                 return;


### PR DESCRIPTION
Extend implementation to handle empty ECG data. The code already handles E_FAIL (or similar) error-codes.