### PR TITLE
TestViewer: Add diagnostics on GetImageSource failure

### DIFF
--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -113,7 +113,13 @@ namespace TestViewer
                 MessageBox.Show(message+": "+err_msg);
                 return;
             }
-            m_source = m_loader.GetImageSource();
+
+            try {
+                m_source = m_loader.GetImageSource();
+            } catch (Exception err) {
+                MessageBox.Show("ERROR: " + err.Message, "GetImageSource error");
+                return;
+            }
 
             FrameSelector.Minimum = 0;
             FrameSelector.Maximum = m_source.GetFrameCount()-1;


### PR DESCRIPTION
Convert HRESULT error codes into an error message displayed in a pop-up dialog. Intended for debugging of loader issues. Note that this is only helpful for loaders that signal an error. Loaders that crash will still not provide any diagnostics.