### PR TITLE
Testviewer out-of-process support

### DIFF
--- a/TestViewer/MainWindow.xaml
+++ b/TestViewer/MainWindow.xaml
@@ -23,7 +23,8 @@
                 <ComboBoxItem>PhilipsLoader.Image3dFileLoader</ComboBoxItem>
                 <ComboBoxItem>KretzLoader.KretzImage3dFileLoader</ComboBoxItem>
             </ComboBox>
-            <Button x:Name="LoadBtn" Click="LoadBtn_Click">Load</Button>
+            <Button x:Name="LoadDefaultBtn" Click="LoadDefaultBtn_Click">Load default</Button>
+            <Button x:Name="LoadOutOfProcBtn" Click="LoadOutOfProcBtn_Click">Load out-of-process</Button>
             <Label>File name</Label>
             <DockPanel>
                 <TextBox Width="160" x:Name="FileName"/>

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -4,9 +4,36 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Diagnostics;
-using System.Windows.Controls.Primitives;
+using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using Image3dAPI;
+
+
+/** Alternative to System.Activator.CreateInstance that allows explicit control over the activation context.
+ *  Based on https://stackoverflow.com/questions/22901224/hosting-managed-code-and-garbage-collection */
+public static class ComExt {
+    [DllImport("ole32.dll", ExactSpelling = true, PreserveSig = false)]
+    static extern void CoCreateInstance(
+       [MarshalAs(UnmanagedType.LPStruct)] Guid rclsid,
+       [MarshalAs(UnmanagedType.IUnknown)] object pUnkOuter,
+       uint dwClsContext,
+       [MarshalAs(UnmanagedType.LPStruct)] Guid riid,
+       [MarshalAs(UnmanagedType.Interface)] out object rReturnedComObject);
+
+    public static object CreateInstance(Guid clsid, bool force_out_of_process) {
+        Guid IID_IUnknown = new Guid("00000000-0000-0000-C000-000000000046");
+        const uint CLSCTX_INPROC_SERVER = 0x1;
+        const uint CLSCTX_LOCAL_SERVER  = 0x4;
+
+        uint class_context = CLSCTX_LOCAL_SERVER; // always allow out-of-process activation
+        if (!force_out_of_process)
+            class_context |= CLSCTX_INPROC_SERVER; // allow in-process activation
+
+        object unk;
+        CoCreateInstance(clsid, null, class_context, IID_IUnknown, out unk);
+        return unk;
+    }
+}
 
 
 namespace TestViewer
@@ -73,7 +100,7 @@ namespace TestViewer
 
             if (m_loader != null)
                 Marshal.ReleaseComObject(m_loader);
-            m_loader = (IImage3dFileLoader)Activator.CreateInstance(comType);
+            m_loader = (IImage3dFileLoader)ComExt.CreateInstance(comType.GUID, false);
 
             this.FileOpenBtn.IsEnabled = true;
         }
@@ -341,7 +368,7 @@ namespace TestViewer
 
         /** Scale bounding-box, so that all axes share the same length.
          *  Also update the origin to keep the bounding-box centered. */
-        static void ExtendBoundingBox(ref Cart3dGeom g)
+static void ExtendBoundingBox(ref Cart3dGeom g)
         {
             float dir1_len = VecLen(g, 1);
             float dir2_len = VecLen(g, 2);

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -71,7 +71,17 @@ namespace TestViewer
             }
         }
 
-        private void LoadBtn_Click(object sender, RoutedEventArgs e)
+        private void LoadDefaultBtn_Click(object sender, RoutedEventArgs e)
+        {
+            LoadImpl(false);
+        }
+
+        private void LoadOutOfProcBtn_Click(object sender, RoutedEventArgs e)
+        {
+            LoadImpl(true);
+        }
+
+        private void LoadImpl(bool force_out_of_proc)
         {
             // try to parse string as ProgId first
             Type comType = Type.GetTypeFromProgID(LoaderName.Text);
@@ -100,7 +110,7 @@ namespace TestViewer
 
             if (m_loader != null)
                 Marshal.ReleaseComObject(m_loader);
-            m_loader = (IImage3dFileLoader)ComExt.CreateInstance(comType.GUID, false);
+            m_loader = (IImage3dFileLoader)ComExt.CreateInstance(comType.GUID, force_out_of_proc);
 
             this.FileOpenBtn.IsEnabled = true;
         }

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -37,6 +37,11 @@ namespace TestViewer
             ImageXZ.Source = null;
             ImageZY.Source = null;
             ECG.Data = null;
+
+            if (m_source != null) {
+                Marshal.ReleaseComObject(m_source);
+                m_source = null;
+            }
         }
 
         private void LoadBtn_Click(object sender, RoutedEventArgs e)
@@ -66,6 +71,8 @@ namespace TestViewer
             // clear UI when switching to a new loader
             ClearUI();
 
+            if (m_loader != null)
+                Marshal.ReleaseComObject(m_loader);
             m_loader = (IImage3dFileLoader)Activator.CreateInstance(comType);
 
             this.FileOpenBtn.IsEnabled = true;
@@ -115,6 +122,8 @@ namespace TestViewer
             }
 
             try {
+                if (m_source != null)
+                    Marshal.ReleaseComObject(m_source);
                 m_source = m_loader.GetImageSource();
             } catch (Exception err) {
                 MessageBox.Show("ERROR: " + err.Message, "GetImageSource error");


### PR DESCRIPTION
Extend TestViewer app with a button to require creation of a loader in a separate process:
![image](https://user-images.githubusercontent.com/2671400/50164430-f94dca00-02e2-11e9-88c0-a88069796720.png)

Done to ease testing of process isolation for loaders. Please note that no security controls are implemented in TestViewer, so the loader process will still have the same permissions as the TestViewer parent process.