### PR TITLE
DummyLoader: Version checking between COM class & API version

### DIFF
--- a/DummyLoader/DummyLoader.idl
+++ b/DummyLoader/DummyLoader.idl
@@ -13,7 +13,7 @@ library DummyLoader
     importlib("stdole2.tlb");
 
     [
-        version(1.0),
+        version(1.2),
         uuid(6FA82ED5-6332-4344-8417-DEA55E72098C),
         helpstring("3D image source")
     ]
@@ -23,7 +23,7 @@ library DummyLoader
     };
 
     [
-        version(1.0),
+        version(1.2),
         uuid(8E754A72-0067-462B-9267-E84AF84828F1),
         helpstring("3D image file loader")
     ]

--- a/DummyLoader/GenRgsFiles.py
+++ b/DummyLoader/GenRgsFiles.py
@@ -23,7 +23,7 @@ text = """HKCR
 				val ThreadingModel = s 'THREAD-MODEL'
 			}
 			TypeLib = s '{TYPE-LIB}'
-			Version = s 'VERSION_MAJOR.VERSION_MINOR'
+			Version = s 'VERSION'
 
 			SupportedManufacturerModels
 			{
@@ -41,11 +41,10 @@ def GenRgsFiles(progname, typelib, version, classes, threadmodel, concat_filenam
         content = text
         content = content.replace('PROG-NAME', progname)
         content = content.replace('TYPE-LIB', typelib)
-        content = content.replace('VERSION_MAJOR', str(version[0]))
-        content = content.replace('VERSION_MINOR', str(version[1]))
         content = content.replace('THREAD-MODEL', threadmodel)
         content = content.replace('CLASS-NAME', cls[0])
         content = content.replace('CLASS-GUID', cls[1])
+        content = content.replace('VERSION',    version)
         
         #print(content)
         filename = cls[0]+'.rgs'
@@ -102,7 +101,7 @@ def ParseImage3dAPIVersion (filename):
                 major = int(line.split()[-1][:-1])
             elif "IMAGE3DAPI_VERSION_MINOR =" in line:
                 minor = int(line.split()[-1][:-1])
-    return [major,minor]
+    return str(major)+"."+str(minor)
 
 
 if __name__ == "__main__":

--- a/DummyLoader/GenRgsFiles.py
+++ b/DummyLoader/GenRgsFiles.py
@@ -35,6 +35,12 @@ text = """HKCR
 }
 """
 
+class ComClass:
+    def __init__(self, name, uuid):
+        self.name = name
+        self.uuid = uuid
+
+
 def GenRgsFiles(progname, typelib, version, classes, threadmodel, concat_filename=None):
     all_rgs_content = ''
     for cls in classes:
@@ -42,12 +48,12 @@ def GenRgsFiles(progname, typelib, version, classes, threadmodel, concat_filenam
         content = content.replace('PROG-NAME', progname)
         content = content.replace('TYPE-LIB', typelib)
         content = content.replace('THREAD-MODEL', threadmodel)
-        content = content.replace('CLASS-NAME', cls[0])
-        content = content.replace('CLASS-GUID', cls[1])
+        content = content.replace('CLASS-NAME', cls.name)
+        content = content.replace('CLASS-GUID', cls.uuid)
         content = content.replace('VERSION',    version)
         
         #print(content)
-        filename = cls[0]+'.rgs'
+        filename = cls.name+'.rgs'
         with open(filename, 'w') as f:
             f.write(content)
             all_rgs_content += content
@@ -90,7 +96,7 @@ def ParseIdl (filename):
             if 'uuid(' in token:
                 uuid = ParseUuidString(token)
                 break
-        classes.append([tokens[-1], uuid])
+        classes.append(ComClass(tokens[-1], uuid))
     
     return libname, typelib, classes
 

--- a/DummyLoader/GenRgsFiles.py
+++ b/DummyLoader/GenRgsFiles.py
@@ -66,8 +66,8 @@ def GenRgsFiles(progname, typelib, version, classes, threadmodel, concat_filenam
         print('Written '+concat_filename)
 
 
-def ParseUuidString (str):
-    uuid = str[str.find('uuid(')+5:]
+def ParseUuidString (val):
+    uuid = val[val.find('uuid(')+5:]
     return uuid[:uuid.find(')')]
 
 


### PR DESCRIPTION
Done to ensure consistency between COM class versions in registry vs. generated type library file (based on the IDL file).

This fixes a current 1.0 vs. 1.2 version inconsistency.