### PR TITLE
Update unregistration scripts

### DIFF
--- a/DummyLoader/UNREGISTER_DummyLoader.bat
+++ b/DummyLoader/UNREGISTER_DummyLoader.bat
@@ -14,14 +14,14 @@ for %%R in (HKEY_LOCAL_MACHINE HKEY_CURRENT_USER) do (
 
   for %%P in (32 64) do (
     :: Image3dSource class
-    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dSource"                        /f /reg:%%P 2> NUL
-    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dSource.1"                      /f /reg:%%P 2> NUL
-    reg delete "%%R\SOFTWARE\Classes\CLSID\{6FA82ED5-6332-4344-8417-DEA55E72098C}"     /f /reg:%%P 2> NUL
+    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dSource"                    /f 2> NUL
+    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dSource.1"                  /f 2> NUL
+    reg delete "%%R\SOFTWARE\Classes\CLSID\{6FA82ED5-6332-4344-8417-DEA55E72098C}" /f /reg:%%P 2> NUL
 
     :: Image3dFileLoader class
-    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dFileLoader"                    /f /reg:%%P 2> NUL
-    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dFileLoader.1"                  /f /reg:%%P 2> NUL
-    reg delete "%%R\SOFTWARE\Classes\CLSID\{8E754A72-0067-462B-9267-E84AF84828F1}"     /f /reg:%%P 2> NUL
+    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dFileLoader"                /f 2> NUL
+    reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dFileLoader.1"              /f 2> NUL
+    reg delete "%%R\SOFTWARE\Classes\CLSID\{8E754A72-0067-462B-9267-E84AF84828F1}" /f /reg:%%P 2> NUL
   )
 )
 

--- a/DummyLoader/UNREGISTER_DummyLoader.bat
+++ b/DummyLoader/UNREGISTER_DummyLoader.bat
@@ -8,11 +8,11 @@ cd /d "%~dp0"
 
 
 :: Remove all traces of DummyLoader from registry
-for %%P in (32 64) do (
-  for %%R in (HKEY_LOCAL_MACHINE HKEY_CURRENT_USER) do (
-    :: TypeLib
-    reg delete "%%R\SOFTWARE\Classes\TypeLib\{67E59584-3F6A-4852-8051-103A4583CA5E}"   /f /reg:%%P 2> NUL
+for %%R in (HKEY_LOCAL_MACHINE HKEY_CURRENT_USER) do (
+  :: TypeLib
+  reg delete "%%R\SOFTWARE\Classes\TypeLib\{67E59584-3F6A-4852-8051-103A4583CA5E}" /f 2> NUL
 
+  for %%P in (32 64) do (
     :: Image3dSource class
     reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dSource"                        /f /reg:%%P 2> NUL
     reg delete "%%R\SOFTWARE\Classes\DummyLoader.Image3dSource.1"                      /f /reg:%%P 2> NUL

--- a/Image3dAPI/UNREGISTER_Image3dAPI.bat
+++ b/Image3dAPI/UNREGISTER_Image3dAPI.bat
@@ -8,6 +8,10 @@ cd /d "%~dp0"
 
 
 :: Remove all traces of Image3dAPI interfaces from registry
+
+:: IImage3dTypeLibraryGenerator.idl
+reg delete "HKCR\TypeLib\{3ff1aab8-f3d8-33d4-825d-00104b3646c0}" /f 2> NUL
+
 for %%P in (32 64) do (
   :: IImage3d.idl
   reg delete "HKCR\Interface\{D483D815-52DD-4750-8CA2-5C6C489588B6}" /f /reg:%%P 2> NUL

--- a/Image3dAPI/UNREGISTER_Image3dAPI.bat
+++ b/Image3dAPI/UNREGISTER_Image3dAPI.bat
@@ -10,8 +10,8 @@ cd /d "%~dp0"
 :: Remove all traces of Image3dAPI interfaces from registry
 for %%P in (32 64) do (
   :: IImage3d.idl
-  reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Interface\{D483D815-52DD-4750-8CA2-5C6C489588B6}" /f /reg:%%P 2> NUL
-  reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Interface\{CD30759B-EB38-4469-9CA5-4DF75737A31B}" /f /reg:%%P 2> NUL
+  reg delete "HKCR\Interface\{D483D815-52DD-4750-8CA2-5C6C489588B6}" /f /reg:%%P 2> NUL
+  reg delete "HKCR\Interface\{CD30759B-EB38-4469-9CA5-4DF75737A31B}" /f /reg:%%P 2> NUL
 )
 
 ::pause


### PR DESCRIPTION
Add missing unregistration of type-library. Also, stop specifying "bitness" for entries stored in joint 32/64bit parts of the registry.