### PR TITLE
Add LoadFile error handling

### DIFF
--- a/RegFreeTest/Main.cpp
+++ b/RegFreeTest/Main.cpp
@@ -55,7 +55,11 @@ int wmain (int argc, wchar_t *argv[]) {
         // load file
         Image3dError err_type = {};
         CComBSTR err_msg;
-        CHECK(loader->LoadFile(filename, &err_type, &err_msg));
+        HRESULT hr = loader->LoadFile(filename, &err_type, &err_msg);
+        if (FAILED(hr)) {
+            std::wcerr << L"LoadFile failed: code=" << err_type << L", message=" << err_msg.m_str << std::endl;
+            return -1;
+        }
     }
 
     CComPtr<IImage3dSource> source;

--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -108,7 +108,11 @@ int wmain (int argc, wchar_t *argv[]) {
         // load file
         Image3dError err_type = {};
         CComBSTR err_msg;
-        CHECK(loader->LoadFile(filename, &err_type, &err_msg));
+        HRESULT hr = loader->LoadFile(filename, &err_type, &err_msg);
+        if (FAILED(hr)) {
+            std::wcerr << L"LoadFile failed: code=" << err_type << L", message="<< err_msg.m_str << std::endl;
+            return -1;
+        }
     }
 
     CComPtr<IImage3dSource> source;

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -131,30 +131,32 @@ namespace TestViewer
         {
             Debug.Assert(m_loader != null);
 
-            Image3dError err_type;
-            string err_msg;
-            m_loader.LoadFile(FileName.Text, out err_type, out err_msg);
-            if ((err_type != Image3dError.Image3d_SUCCESS))
-            {
-                string message;
-                switch (err_type) {
-                    case Image3dError.Image3d_ACCESS_FAILURE:
-                        message = "Unable to open the file. The file might be missing or locked.";
-                        break;
-                    case Image3dError.Image3d_VALIDATION_FAILURE:
-                        message = "Unsupported file. Probably due to unsupported vendor or modality.";
-                        break;
-                    case Image3dError.Image3d_NOT_YET_SUPPORTED:
-                        message = "The loader is too old to parse the file.";
-                        break;
-                    case Image3dError.Image3d_SUPPORT_DISCONTINUED:
-                        message = "The the file version is no longer supported (pre-DICOM format?).";
-                        break;
-                    default:
-                        message = "Unknown error";
-                        break;
+            Image3dError err_type = Image3dError.Image3d_SUCCESS;
+            string err_msg = "";
+            try {
+                m_loader.LoadFile(FileName.Text, out err_type, out err_msg);
+            } catch (Exception) {
+                // NOTE: err_msg does not seem to be marshaled back on LoadFile failure in .Net.
+                // NOTE: This problem is limited to .Net, and does not occur in C++
+
+                string message = "Unknown error";
+                if ((err_type != Image3dError.Image3d_SUCCESS)) {
+                    switch (err_type) {
+                        case Image3dError.Image3d_ACCESS_FAILURE:
+                            message = "Unable to open the file. The file might be missing or locked.";
+                            break;
+                        case Image3dError.Image3d_VALIDATION_FAILURE:
+                            message = "Unsupported file. Probably due to unsupported vendor or modality.";
+                            break;
+                        case Image3dError.Image3d_NOT_YET_SUPPORTED:
+                            message = "The loader is too old to parse the file.";
+                            break;
+                        case Image3dError.Image3d_SUPPORT_DISCONTINUED:
+                            message = "The the file version is no longer supported (pre-DICOM format?).";
+                            break;
+                    }
                 }
-                MessageBox.Show(message+": "+err_msg);
+                MessageBox.Show("LoadFile error: " + message + " (" + err_msg+")");
                 return;
             }
 


### PR DESCRIPTION
Update C++ and C# sample projects to more properly handle `LoadFile` errors.