### PR TITLE
Add exception catching for version checking code

### DIFF
--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -97,12 +97,17 @@ namespace TestViewer
             }
 
             // API version compatibility check
-            RegistryKey ver_key = Registry.ClassesRoot.OpenSubKey("CLSID\\{"+comType.GUID+"}\\Version");
-            string ver_str = (string)ver_key.GetValue("");
-            string cur_ver = string.Format("{0}.{1}", (int)Image3dAPIVersion.IMAGE3DAPI_VERSION_MAJOR, (int)Image3dAPIVersion.IMAGE3DAPI_VERSION_MINOR);
-            if (ver_str != cur_ver) {
-                MessageBox.Show(string.Format("Incompatible loader version. Loader uses version {0}, while the current version is {1}.", ver_str, cur_ver));
-                return;
+            try {
+                RegistryKey ver_key = Registry.ClassesRoot.OpenSubKey("CLSID\\{" + comType.GUID + "}\\Version");
+                string ver_str = (string)ver_key.GetValue("");
+                string cur_ver = string.Format("{0}.{1}", (int)Image3dAPIVersion.IMAGE3DAPI_VERSION_MAJOR, (int)Image3dAPIVersion.IMAGE3DAPI_VERSION_MINOR);
+                if (ver_str != cur_ver) {
+                    MessageBox.Show(string.Format("Loader uses version {0}, while the current version is {1}.", ver_str, cur_ver), "Incompatible loader version");
+                    return;
+                }
+            } catch (Exception err) {
+                MessageBox.Show(err.Message, "Version check error");
+                // continue, since this error will also appear if the loader has non-matching bitness
             }
 
             // clear UI when switching to a new loader


### PR DESCRIPTION
This code will throw if only a loader with non-matching bitness is installed, leading to a crash. This change will at least provide some information back to the user regarding the failure. Also, it's no longer fatal.

The best solution here would be to also search thought the part of the registry with non-matching bitness as SandboxTest already does. However, that can be improved later.