### PR TITLE
DOC: Return empty EcgSeries if EGC is not available

### DIFF
--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -294,7 +294,7 @@ interface IImage3dSource : IUnknown {
     [helpstring("Retrieve color-map table for mapping image intensities to RGBx values. Length is 256.")]
     HRESULT GetColorMap ([out,retval] SAFEARRAY(unsigned int) * map);
 
-    [helpstring("Get ECG data if available [optional]")]
+    [helpstring("Get ECG data if available [optional]. Shall return S_OK with an empty EcgSeries if EGC is not available.")]
     HRESULT GetECG ([out,retval] EcgSeries * ecg);
 
     [helpstring("")]


### PR DESCRIPTION
Proposal to clarify API documentation as requested in https://github.com/MedicalUltrasound/Image3dAPI/issues/115.

I don't really have any preference on if lack of ECG should be reported as E_FAIL (or other error code) and/or an empty ECG struct, so we can just as well fail if there's a request for that.