### PR TITLE
SandboxTest: Add basic loader profiling

### DIFF
--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -1,9 +1,32 @@
 #include "../Image3dAPI/ComSupport.hpp"
 #include "../Image3dAPI/IImage3d.h"
 #include "../Image3dAPI/RegistryCheck.hpp"
+#include <chrono>
 #include <iostream>
 #include <fstream>
 #include <sddl.h>
+
+
+class PerfTimer {
+    using clock = std::chrono::high_resolution_clock;
+public:
+    PerfTimer(const char * prefix, bool enable) : m_prefix(prefix) {
+        if (enable)
+            m_start = clock::now();
+
+    }
+    ~PerfTimer() {
+        if (m_start == clock::time_point())
+            return; // profiling disabled
+
+        auto stop = clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - m_start).count();
+        std::cout << m_prefix << " took " << duration << "ms\n";
+    }
+private:
+    const char *      m_prefix;
+    clock::time_point m_start;
+};
 
 
 /** RAII class for temporarily impersonating low-integrity level for the current thread.
@@ -53,7 +76,7 @@ private:
 };
 
 
-void ParseSource (IImage3dSource & source, bool verbose) {
+void ParseSource (IImage3dSource & source, bool verbose, bool profile) {
     Cart3dGeom geom = {};
     CHECK(source.GetBoundingBox(&geom));
 
@@ -91,6 +114,7 @@ void ParseSource (IImage3dSource & source, bool verbose) {
 
         // retrieve frame data
         Image3d data;
+        PerfTimer timer("GetFrame", profile);
         CHECK(source.GetFrame(frame, geom, max_res, &data));
     }
 }
@@ -99,7 +123,7 @@ void ParseSource (IImage3dSource & source, bool verbose) {
 int wmain (int argc, wchar_t *argv[]) {
     if (argc < 3) {
         std::wcout << L"Usage:\n";
-        std::wcout << L"SandboxTest.exe <loader-progid> <filename> [-verbose]" << std::endl;
+        std::wcout << L"SandboxTest.exe <loader-progid> <filename> [-verbose|-profile]" << std::endl;
         return -1;
     }
 
@@ -107,9 +131,12 @@ int wmain (int argc, wchar_t *argv[]) {
     CComBSTR filename = argv[2];
 
     bool verbose = false; // more extensive logging
+    bool profile = false; // profile loader performance
     if (argc >= 4) {
         if (std::wstring(argv[3]) == L"-verbose")
             verbose = true;
+        else if (std::wstring(argv[3]) == L"-profile")
+            profile = true;
     }
 
     bool test_locked_input = true;
@@ -151,6 +178,7 @@ int wmain (int argc, wchar_t *argv[]) {
     {
         std::wcout << L"Creating loader " << progid.m_str << L" in low-integrity mode...\n";
         LowIntegrity low_integrity;
+        PerfTimer timer("CoCreateInstance", profile);
         CHECK(loader.CoCreateInstance(clsid, nullptr, CLSCTX_LOCAL_SERVER | CLSCTX_ENABLE_CLOAKING));
     }
 
@@ -158,6 +186,7 @@ int wmain (int argc, wchar_t *argv[]) {
         // load file
         Image3dError err_type = {};
         CComBSTR err_msg;
+        PerfTimer timer("LoadFile", profile);
         HRESULT hr = loader->LoadFile(filename, &err_type, &err_msg);
         if (FAILED(hr)) {
             std::wcerr << L"LoadFile failed: code=" << err_type << L", message="<< err_msg.m_str << std::endl;
@@ -166,7 +195,10 @@ int wmain (int argc, wchar_t *argv[]) {
     }
 
     CComPtr<IImage3dSource> source;
-    CHECK(loader->GetImageSource(&source));
+    {
+        PerfTimer timer("GetImageSource", profile);
+        CHECK(loader->GetImageSource(&source));
+    }
 
     ProbeInfo probe;
     CHECK(source->GetProbeInfo(&probe));
@@ -174,7 +206,7 @@ int wmain (int argc, wchar_t *argv[]) {
     EcgSeries ecg;
     CHECK(source->GetECG(&ecg));
 
-    ParseSource(*source, verbose);
+    ParseSource(*source, verbose, profile);
 
     return 0;
 }

--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -53,15 +53,17 @@ private:
 };
 
 
-void ParseSource (IImage3dSource & source) {
+void ParseSource (IImage3dSource & source, bool verbose) {
     Cart3dGeom geom = {};
     CHECK(source.GetBoundingBox(&geom));
 
-    std::cout << "Bounding box:\n";
-    std::cout << "  Origin: " << geom.origin_x<< ", " << geom.origin_y << ", " << geom.origin_z << "\n";
-    std::cout << "  Dir1:   " << geom.dir1_x  << ", " << geom.dir1_y   << ", " << geom.dir1_z   << "\n";
-    std::cout << "  Dir2:   " << geom.dir2_x  << ", " << geom.dir2_y   << ", " << geom.dir2_z   << "\n";
-    std::cout << "  Dir3:   " << geom.dir3_x  << ", " << geom.dir3_y   << ", " << geom.dir3_z   << "\n";
+    if (verbose) {
+        std::cout << "Bounding box:\n";
+        std::cout << "  Origin: " << geom.origin_x << ", " << geom.origin_y << ", " << geom.origin_z << "\n";
+        std::cout << "  Dir1:   " << geom.dir1_x   << ", " << geom.dir1_y   << ", " << geom.dir1_z   << "\n";
+        std::cout << "  Dir2:   " << geom.dir2_x   << ", " << geom.dir2_y   << ", " << geom.dir2_z   << "\n";
+        std::cout << "  Dir3:   " << geom.dir3_x   << ", " << geom.dir3_y   << ", " << geom.dir3_z   << "\n";
+    }
 
     unsigned int frame_count = 0;
     CHECK(source.GetFrameCount(&frame_count));
@@ -75,11 +77,13 @@ void ParseSource (IImage3dSource & source) {
         tmp = nullptr;
     }
 
-    std::cout << "Color-map:\n";
-    for (unsigned int i = 0; i < color_map.GetCount(); i++) {
-        unsigned int color = color_map[(int)i];
-        uint8_t *rgbx = reinterpret_cast<uint8_t*>(&color);
-        std::cout << "  [" << (int)rgbx[0] << "," << (int)rgbx[1] << "," << (int)rgbx[2] << "," << (int)rgbx[3] << "]\n";
+    if (verbose) {
+        std::cout << "Color-map:\n";
+        for (unsigned int i = 0; i < color_map.GetCount(); i++) {
+            unsigned int color = color_map[(int)i];
+            uint8_t *rgbx = reinterpret_cast<uint8_t*>(&color);
+            std::cout << "  [" << (int)rgbx[0] << "," << (int)rgbx[1] << "," << (int)rgbx[2] << "," << (int)rgbx[3] << "]\n";
+        }
     }
 
     for (unsigned int frame = 0; frame < frame_count; ++frame) {
@@ -95,12 +99,19 @@ void ParseSource (IImage3dSource & source) {
 int wmain (int argc, wchar_t *argv[]) {
     if (argc < 3) {
         std::wcout << L"Usage:\n";
-        std::wcout << L"SandboxTest.exe <loader-progid> <filename>" << std::endl;
+        std::wcout << L"SandboxTest.exe <loader-progid> <filename> [-verbose]" << std::endl;
         return -1;
     }
 
     CComBSTR progid = argv[1];  // e.g. "DummyLoader.Image3dFileLoader"
     CComBSTR filename = argv[2];
+
+    bool verbose = false; // more extensive logging
+    if (argc >= 4) {
+        if (std::wstring(argv[3]) == L"-verbose")
+            verbose = true;
+    }
+
     bool test_locked_input = true;
 
     std::ifstream locked_file;
@@ -163,7 +174,7 @@ int wmain (int argc, wchar_t *argv[]) {
     EcgSeries ecg;
     CHECK(source->GetECG(&ecg));
 
-    ParseSource(*source);
+    ParseSource(*source, verbose);
 
     return 0;
 }


### PR DESCRIPTION
### SandboxTest changes
* Reduce logging unless new "-verbose" command-line argument is provided.
* Enable profiling of the most important API calls through a new "-profile" command-line argument.


### Example output
Example output when running in "-profile" mode:
```
Open file: C:\Dev\3d_test.dcm to test read-locked input file in loader.
Creating loader GEHC_CARD_US.Image3dFileLoader in low-integrity mode...
CoCreateInstance took 214ms
LoadFile took 69ms
GetImageSource took 19ms
Frame count: 18
GetFrame took 11ms
GetFrame took 9ms
GetFrame took 10ms
GetFrame took 10ms
...
```

Example output when running in "-verbose" mode:
```
Open file: C:\Dev\3d_test.dcm to test read-locked input file in loader.
Creating loader GEHC_CARD_US.Image3dFileLoader in low-integrity mode...
Bounding box:
  Origin: -0.0741915, -0.000170385, 0.0742264
  Dir1:   0.148383, 0, 0
  Dir2:   0, 0, -0.148453
  Dir3:   0, 0.16017, 0
Frame count: 18
Color-map:
  [0,0,0,255]
  [0,0,0,255]
  [0,0,0,255]
  [0,0,0,255]
...
```