### PR TITLE
API: Add color-flow support (GE proposal)

### DIFF
--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -80,7 +80,7 @@ Image3dSource::Image3dSource() {
             Image3d tmp;
             {
                 tmp.time = f*(duration/numFrames) + startTime;
-                tmp.format = FORMAT_U8;
+                tmp.format = IMAGE_FORMAT_U8;
                 for (size_t i = 0; i < 3; ++i)
                     tmp.dims[i] = dims[i];
                 CComSafeArray<BYTE> data(static_cast<unsigned int>(img_buf.size()));
@@ -201,7 +201,7 @@ Image3d Image3dSource::SampleFrame (const Image3d & frame, Cart3dGeom out_geom, 
     Image3d result;
     {
         result.time = frame.time;
-        result.format = FORMAT_U8;
+        result.format = IMAGE_FORMAT_U8;
         for (size_t i = 0; i < 3; ++i)
             result.dims[i] = max_res[i];
         CComSafeArray<BYTE> data(static_cast<unsigned int>(img_buf.size()));

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -29,6 +29,7 @@ enum ImageFormat {
     IMAGE_FORMAT_INVALID   = 0, ///< make sure that "cleared" state is invalid
     IMAGE_FORMAT_U8        = 1, ///< unsigned 8bit grayscale
     IMAGE_FORMAT_FREQ8POW8 = 2, ///< 16bit color-flow format (8bit signed frequency value, 8bit unsigned power/bandwidth value)
+    IMAGE_FORMAT_R8G8B8A8  = 3, ///< 32bit RGBA (alpha channel ignored)
 } ImageFormat;
 
 

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -32,6 +32,15 @@ enum ImageFormat {
     IMAGE_FORMAT_R8G8B8A8  = 3, ///< 32bit RGBA (alpha channel ignored)
 } ImageFormat;
 
+typedef [
+    v1_enum, // 32bit enum size
+    helpstring("Enum of supported color-map formats (extended upon demand).")]
+enum ColorMapType {
+    TYPE_TISSUE_COLOR, ///< tisse color-map; type=R8G8B8A8   (for slicing)
+    TYPE_FLOW_COLOR,   ///< flow color-map; type=R8G8B8A8    (for slicing, in freq&bw space)
+    TYPE_FLOW_ARB,     ///< flow arbitration; type=FREQ8POW8 (for deciding if tissue or flow shall be shown)
+} ColorMapType;
+
 
 typedef [
   v1_enum, // 32bit enum size
@@ -293,8 +302,8 @@ interface IImage3dSource : IUnknown {
     [helpstring("Get a bounding box encapsulating all image data. Can be used as intput to GetFrame to avoid cropping.")]
     HRESULT GetBoundingBox ([out,retval] Cart3dGeom * geom);
 
-    [helpstring("Retrieve color-map table for mapping image intensities to RGBx values. Length is 256.")]
-    HRESULT GetColorMap ([out,retval] SAFEARRAY(unsigned int) * map);
+    [helpstring("Retrieve color-map table for mapping image intensities to RGBx values. Length depend on format.")]
+    HRESULT GetColorMap ([in] ColorMapType type, [out] ImageFormat * format, [out,retval] SAFEARRAY(unsigned int) * table);
 
     [helpstring("Get ECG data if available [optional]. Shall return S_OK with an empty EcgSeries if EGC is not available.")]
     HRESULT GetECG ([out,retval] EcgSeries * ecg);

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -26,8 +26,9 @@ typedef [
   v1_enum, // 32bit enum size
   helpstring("Enum of supported image formats (extended upon demand).")]
 enum ImageFormat {
-    FORMAT_INVALID  = 0, ///< make sure that "cleared" state is invalid
-    FORMAT_U8       = 1, ///< unsigned 8bit grayscale
+    IMAGE_FORMAT_INVALID   = 0, ///< make sure that "cleared" state is invalid
+    IMAGE_FORMAT_U8        = 1, ///< unsigned 8bit grayscale
+    IMAGE_FORMAT_FREQ8POW8 = 2, ///< 16bit color-flow format (8bit signed frequency value, 8bit unsigned power/bandwidth value)
 } ImageFormat;
 
 
@@ -96,7 +97,7 @@ cpp_quote("} // extern \"C\"")
 cpp_quote("")
 cpp_quote("struct Image3d {")
 cpp_quote("    double         time    = 0;")
-cpp_quote("    ImageFormat    format  = FORMAT_INVALID;")
+cpp_quote("    ImageFormat    format  = IMAGE_FORMAT_INVALID;")
 cpp_quote("    unsigned short dims[3] = {0,0,0};")
 cpp_quote("    unsigned int   stride0 = 0;")
 cpp_quote("    unsigned int   stride1 = 0;")

--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -23,6 +23,15 @@ enum Image3dAPIVersion {
 
 
 typedef [
+    v1_enum, // 32bit enum size
+    helpstring("Enum of supported image types (extended upon demand).")]
+enum ImageType {
+    IMAGE_TYPE_INVALID   = 0, ///< make sure that "cleared" state is invalid
+    IMAGE_TYPE_TISSUE    = 1, ///< grayscale B-mode image
+    IMAGE_TYPE_BLOOD_VEL = 2, ///< blood velocities (color-flow) (rel. to probe)
+} ImageType;
+
+typedef [
   v1_enum, // 32bit enum size
   helpstring("Enum of supported image formats (extended upon demand).")]
 enum ImageFormat {
@@ -285,21 +294,40 @@ cpp_quote("#else")
 cpp_quote("static_assert(sizeof(EcgSeries) == 2*8+2*4, \"EcgSeries size mismatch\");")
 cpp_quote("#endif")
 
-[ object,
-  oleautomation, // use "automation" marshaler (oleaut32.dll)
-  uuid(D483D815-52DD-4750-8CA2-5C6C489588B6),
-  helpstring("Interface for retrieving 3D image data.")]
-interface IImage3dSource : IUnknown {
+
+[object,
+    oleautomation, // use "automation" marshaler (oleaut32.dll)
+    uuid(D7D2A41A-F738-41EB-8133-1B06DDA1FF40),
+    helpstring("3D image stream interface. Used to group frames sharing a common type (e.g. tissue or color-flow).")]
+interface IImage3dStream : IUnknown {
+    [helpstring("Get stream type.")]
+    HRESULT GetType ([out, retval] ImageType * type);
+
     [helpstring("Get the number of frames available")]
-    HRESULT GetFrameCount ([out,retval] unsigned int * size);
+    HRESULT GetFrameCount ([out, retval] unsigned int * size);
 
     [helpstring("Get the time of all frames (useful for matching frame indices to ECG before retrieving image data) ")]
     HRESULT GetFrameTimes ([out, retval] SAFEARRAY(double) * frame_times);
 
     [helpstring("Get image data (const) for a given frame within a specified geometry")]
-    HRESULT GetFrame ([in] unsigned int index, [in] Cart3dGeom geom, [in] unsigned short max_resolution[3], [out,retval] Image3d * data);
+    HRESULT GetFrame ([in] unsigned int index, [out, retval] Image3d * data);
+};
 
-    [helpstring("Get a bounding box encapsulating all image data. Can be used as intput to GetFrame to avoid cropping.")]
+
+[ object,
+  oleautomation, // use "automation" marshaler (oleaut32.dll)
+  uuid(D483D815-52DD-4750-8CA2-5C6C489588B6),
+  helpstring("Interface for retrieving 3D image data.")]
+interface IImage3dSource : IUnknown {
+    [helpstring("Get the number of streams available.")]
+    HRESULT GetStreamCount ([out, retval] unsigned int * size);
+
+    [helpstring("Get cartesian image stream. The geometry and resolution arguments are advisory, and might not be honored.\n"
+                "Clients should therefore check the actual geometry and resolution of the retrieved stream afterwards.")]
+    HRESULT GetStream ([in] int index, [in] Cart3dGeom geom, [in] unsigned int max_resolution[3], [out, retval] IImage3dStream ** stream);
+
+
+    [helpstring("Get a bounding box encapsulating all image data. Can be used as intput to GetStream to avoid cropping.")]
     HRESULT GetBoundingBox ([out,retval] Cart3dGeom * geom);
 
     [helpstring("Retrieve color-map table for mapping image intensities to RGBx values. Length depend on format.")]

--- a/Image3dAPI/UNREGISTER_Image3dAPI.bat
+++ b/Image3dAPI/UNREGISTER_Image3dAPI.bat
@@ -14,6 +14,7 @@ reg delete "HKCR\TypeLib\{3ff1aab8-f3d8-33d4-825d-00104b3646c0}" /f 2> NUL
 
 for %%P in (32 64) do (
   :: IImage3d.idl
+  reg delete "HKCR\Interface\{D7D2A41A-F738-41EB-8133-1B06DDA1FF40}" /f /reg:%%P 2> NUL
   reg delete "HKCR\Interface\{D483D815-52DD-4750-8CA2-5C6C489588B6}" /f /reg:%%P 2> NUL
   reg delete "HKCR\Interface\{CD30759B-EB38-4469-9CA5-4DF75737A31B}" /f /reg:%%P 2> NUL
 )


### PR DESCRIPTION
Proposal to extend the API to also support display of color-flow data, in addition to tissue. This is intended to be a simple representation that is compatible with the way color-flow data is processed by any vendor.

Please note that the color-flow appearance is unlikely to exactly match the appearance on the original system, since the "internal" vendor encoding and algorithms are likely to be more advanced. The goal is therefore to get visual appearance that is fairly close to the original.

Integration of this extension will probably require bidirectional code for converting between the "internal" vendor encoding and the Image3dAPI encoding of flow data.


Changes:
* New 16bit color-flow format (8bit signed frequency value, 8bit unsigned power/bandwidth value)
* New color-map types for "flow color" [RGB] and "flow arbitration" [FreqPow]
* New `IImage3dStream` interface for grouping together "tissue" vs. "flow" frames


### Tissue vs. flow algorithm:
```
/** Reference algorithm for displaying "tissue" vs. "flow" data for a given on-screen pixel.
    Optimized for readability, not for speed. */
static RGBA ColorLookop(uint8_t tissue_val,
                        uint16_t flow_val,
                        array<RGBA,    256>     tissue_cm,
                        array<RGBA,    256*256> flow_cm,
                        array<uint8_t, 256*256> flow_arb) {

    if (flow_arb[flow_val] > tissue_val)
        return flow_cm[flow_val]; // display flow
    else
        return tissue_cm[tissue_val]; // display tissue
}
```
