### PR TITLE
API: Limited "presentation state" support (GE proposal)

### DIFF
--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -274,6 +274,22 @@ cpp_quote("#else")
 cpp_quote("static_assert(sizeof(EcgSeries) == 2*8+2*4, \"EcgSeries size mismatch\");")
 cpp_quote("#endif")
 
+
+[object,
+ oleautomation, // use "automation" marshaler (oleaut32.dll)
+ uuid(DCAC585F-3EC1-4440-96B6-83090408B027),
+ helpstring("Interface for retrieving the default slice/rendering 'views' of the 3D data.")]
+interface IPresentationState : IUnknown {
+    [helpstring("Get number of default slice/rendering views.\n"
+                "Shall return 0 if no default views are available.")]
+    HRESULT GetViewCount ([out, retval] unsigned int * count);
+
+    [helpstring("Get slice/rendering view by index.\n"
+                "The views shall by sorted by 'importance'. Clients unable to display all views should therefore display the first 'N' views.\n"
+                "Slices are indicated by the 'dir3' vector being empty, whereas it is non-empty for renderings.")]
+    HRESULT GetView ([in] unsigned int index, [out, retval] Cart3dGeom * view);
+};
+
 [ object,
   oleautomation, // use "automation" marshaler (oleaut32.dll)
   uuid(D483D815-52DD-4750-8CA2-5C6C489588B6),
@@ -296,6 +312,9 @@ interface IImage3dSource : IUnknown {
 
     [helpstring("Get ECG data if available [optional]. Shall return S_OK with an empty EcgSeries if EGC is not available.")]
     HRESULT GetECG ([out,retval] EcgSeries * ecg);
+
+    [helpstring("Get presentation state corresponding to the 'views' shown on screen when the data was originally stored [optional].")]
+    HRESULT GetPresentationState (IPresentationState * pstate);
 
     [helpstring("")]
     HRESULT GetProbeInfo ([out,retval] ProbeInfo * probe);

--- a/Image3dAPI/UNREGISTER_Image3dAPI.bat
+++ b/Image3dAPI/UNREGISTER_Image3dAPI.bat
@@ -16,6 +16,7 @@ for %%P in (32 64) do (
   :: IImage3d.idl
   reg delete "HKCR\Interface\{D483D815-52DD-4750-8CA2-5C6C489588B6}" /f /reg:%%P 2> NUL
   reg delete "HKCR\Interface\{CD30759B-EB38-4469-9CA5-4DF75737A31B}" /f /reg:%%P 2> NUL
+  reg delete "HKCR\Interface\{DCAC585F-3EC1-4440-96B6-83090408B027}" /f /reg:%%P 2> NUL
 )
 
 ::pause


### PR DESCRIPTION
This will expose a sorted list of slice/rendering "views" that clients can utilize to reconstruct slice/rendering views that are similar to the views shown on screen when saving the original data.

Out of scope for now:
* The on-screen layout is currently _not_ exposed. Clients will need to handle positioning themselves, which might not match the original layout.
* Perspective projections is not currently supported, only a orthographic cube. Clip-planes is similarly not supported either. Implementers will therefore need to expose the orthographic representation that most closely resembles what is displayed on the original system.

Views are encoded with the following parameters:
* Origin: x,y,z (top-left corner of the view)
* dir1: x,y,z (directional vector from top-left to top-right corner)
* dir2: x.y,z (directional vector from top-left to bottom-right corner)
* dir3: x.y,z (directional vector from front-top-left to back-top-left corner). Zero on slices.

Assumptions:
* It's possible to somehow infer the default slice/rendering "views" from a rawdicom file.
* It's possible to dynamically change the "views" in the PACS system based on this metadata.

### Example
![image](https://user-images.githubusercontent.com/2671400/62422110-9102fb80-b6ad-11e9-916a-a1c6d07e3a5a.png)
