### PR TITLE
Clarify EcgSeries trig_times documentation

### DIFF
--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -198,7 +198,7 @@ struct EcgSeries {
     [helpstring("ECG sample waveform")]
     SAFEARRAY(float) samples;
 
-    [helpstring("QRS trig time(s) within series [optional]")]
+    [helpstring("QRS/R-wave trig time(s) [seconds] within series [optional]")]
     SAFEARRAY(double) trig_times;
 } EcgSeries;
 


### PR DESCRIPTION
Make it clear that the trig-times are for the R-wave or QRS, depending on terminology. Also, document that the unit is seconds, just like for all other time values.