### PR TITLE
Clarify that GetFrame might return a frame with lower resolution than…

### DIFF
--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -285,7 +285,7 @@ interface IImage3dSource : IUnknown {
     [helpstring("Get the time of all frames (useful for matching frame indices to ECG before retrieving image data) ")]
     HRESULT GetFrameTimes ([out, retval] SAFEARRAY(double) * frame_times);
 
-    [helpstring("Get image data (const) for a given frame within a specified geometry")]
+    [helpstring("Get image data (const) for a given frame within a specified geometry. The returned frame might have lower resolution than requested.")]
     HRESULT GetFrame ([in] unsigned int index, [in] Cart3dGeom geom, [in] unsigned short max_resolution[3], [out,retval] Image3d * data);
 
     [helpstring("Get a bounding box encapsulating all image data. Can be used as intput to GetFrame to avoid cropping.")]


### PR DESCRIPTION
… requested

Loaders are allowed to put restrictions on the maximum obtainable resolution. This might be due to memory consumption, computational overhead or IP-related reasons.