### PR TITLE
Add printing SOP Instance UID to test method GetSopInstanceUID.

### DIFF
--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -235,7 +235,7 @@ int wmain (int argc, wchar_t *argv[]) {
 
     ProbeInfo probe;
     CHECK(source->GetProbeInfo(&probe));
-    std::wcout << "Probe name: " << probe.name.m_str << L"\n";
+    std::wcout << L"Probe name: " << probe.name.m_str << L"\n";
 
     EcgSeries ecg;
     CHECK(source->GetECG(&ecg));

--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -227,6 +227,12 @@ int wmain (int argc, wchar_t *argv[]) {
         CHECK(loader->GetImageSource(&source));
     }
 
+    {
+        CComBSTR sopInstanceUID;
+        CHECK(source->GetSopInstanceUID(&sopInstanceUID));
+        std::wcout << L"SOP Instance UID: " << sopInstanceUID.m_str << L"\n";
+    }
+
     ProbeInfo probe;
     CHECK(source->GetProbeInfo(&probe));
     std::wcout << "Probe name: " << probe.name.m_str << L"\n";


### PR DESCRIPTION
Add missing test of GetSopInstanceUID in SandboxTest.