### PR TITLE
Move instantiation loader to a separate thread.

### DIFF
--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -216,7 +216,7 @@ int wmain(int argc, wchar_t *argv[]) {
         locked_file.open(filename);
     }
 
-    ComInitialize com(COINIT_MULTITHREADED);
+    ComInitialize com(COINIT_APARTMENTTHREADED);
 
     CLSID clsid = {};
     if (FAILED(CLSIDFromProgID(progid, &clsid))) {


### PR DESCRIPTION
Add a new command-line option `-threading` to instantiate loader, load file and get image source in a separate thread.