### PR TITLE
Move R8G8B8A8 struct over to a new Image3dStream header

### DIFF
--- a/DummyLoader/DummyLoader.vcxproj
+++ b/DummyLoader/DummyLoader.vcxproj
@@ -253,11 +253,13 @@
   <ItemGroup>
     <ClCompile Include="Image3dFileLoader.cpp" />
     <ClCompile Include="Image3dSource.cpp" />
+    <ClCompile Include="Image3dStream.cpp" />
     <ClCompile Include="Main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Image3dFileLoader.hpp" />
     <ClInclude Include="Image3dSource.hpp" />
+    <ClInclude Include="Image3dStream.hpp" />
     <ClInclude Include="LinAlg.hpp" />
     <ClInclude Include="Resource.h" />
   </ItemGroup>

--- a/DummyLoader/DummyLoader.vcxproj.filters
+++ b/DummyLoader/DummyLoader.vcxproj.filters
@@ -4,12 +4,14 @@
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Image3dSource.cpp" />
     <ClCompile Include="Image3dFileLoader.cpp" />
+    <ClCompile Include="Image3dStream.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Image3dSource.hpp" />
     <ClInclude Include="Image3dFileLoader.hpp" />
     <ClInclude Include="Resource.h" />
     <ClInclude Include="LinAlg.hpp" />
+    <ClInclude Include="Image3dStream.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="GenRgsFiles.py" />

--- a/DummyLoader/Image3dSource.hpp
+++ b/DummyLoader/Image3dSource.hpp
@@ -3,34 +3,8 @@ Designed by Fredrik Orderud <fredrik.orderud@ge.com>.
 Copyright (c) 2016, GE Healthcare, Ultrasound.      */
 #pragma once
 
-#define _USE_MATH_DEFINES // for M_PI
-#include <cmath>
-#include <memory>
-#include <array>
-#include <vector>
-#include "../Image3dAPI/ComSupport.hpp"
-#include "../Image3dAPI/IImage3d.h"
+#include "Image3dStream.hpp"
 
-#include "DummyLoader.h"
-#include "Resource.h"
-
-
-/** RGBA color struct that matches DXGI_FORMAT_R8G8B8A8_UNORM.
-Created due to the lack of such a class/struct in the Windows or Direct3D SDKs.
-Please remove this class if a more standardized alternative is available. */
-struct R8G8B8A8 {
-    R8G8B8A8 () : r(0), g(0), b(0), a(0) {
-    }
-
-    R8G8B8A8 (unsigned char _r, unsigned char _g, unsigned char _b, unsigned char _a) : r(_r), g(_g), b(_b), a(_a) {
-    }
-
-    operator unsigned int () const {
-        return *reinterpret_cast<const unsigned int*>(this);
-    }
-
-    unsigned char r, g, b, a;  ///< color channels
-};
 
 
 class ATL_NO_VTABLE Image3dSource :

--- a/DummyLoader/Image3dStream.cpp
+++ b/DummyLoader/Image3dStream.cpp
@@ -1,0 +1,1 @@
+#include "Image3dStream.hpp"

--- a/DummyLoader/Image3dStream.hpp
+++ b/DummyLoader/Image3dStream.hpp
@@ -1,0 +1,33 @@
+/* Dummy test loader for the "3D API".
+Designed by Fredrik Orderud <fredrik.orderud@ge.com>.
+Copyright (c) 2020, GE Healthcare, Ultrasound.      */
+#pragma once
+
+#define _USE_MATH_DEFINES // for M_PI
+#include <cmath>
+#include <memory>
+#include <array>
+#include <vector>
+#include "../Image3dAPI/ComSupport.hpp"
+#include "../Image3dAPI/IImage3d.h"
+
+#include "DummyLoader.h"
+#include "Resource.h"
+
+
+/** RGBA color struct that matches DXGI_FORMAT_R8G8B8A8_UNORM.
+Created due to the lack of such a class/struct in the Windows or Direct3D SDKs.
+Please remove this class if a more standardized alternative is available. */
+struct R8G8B8A8 {
+    R8G8B8A8 () : r(0), g(0), b(0), a(0) {
+    }
+
+    R8G8B8A8 (unsigned char _r, unsigned char _g, unsigned char _b, unsigned char _a) : r(_r), g(_g), b(_b), a(_a) {
+    }
+
+    operator unsigned int () const {
+        return *reinterpret_cast<const unsigned int*>(this);
+    }
+
+    unsigned char r, g, b, a;  ///< color channels
+};


### PR DESCRIPTION
Preparation before upcoming API change. There are no functional changes in this PR.