### PR TITLE
DummyLoader: Increase TypeLib version to match COM class versions

### DIFF
--- a/DummyLoader/DummyLoader.idl
+++ b/DummyLoader/DummyLoader.idl
@@ -4,7 +4,7 @@ import "IImage3d.idl";
 
 
 [
-    version(1.0),
+    version(1.2),
     uuid(67E59584-3F6A-4852-8051-103A4583CA5E),
     helpstring("DummyLoader module")
 ]


### PR DESCRIPTION
Microsoft states that the COM class version should match the assoicated TypeLib version: https://docs.microsoft.com/en-us/windows/win32/com/version