### PR TITLE
Fix failing post-build registration when there's whitespace in the folder path

### DIFF
--- a/Image3dAPI/Image3dAPI.vcxproj
+++ b/Image3dAPI/Image3dAPI.vcxproj
@@ -88,7 +88,7 @@
       <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+      <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:"$(OutDir)$(TargetName).dll"
 :: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
 xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1
@@ -112,7 +112,7 @@ xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b
       <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+      <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:"$(OutDir)$(TargetName).dll"
 :: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
 xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1
@@ -140,7 +140,7 @@ xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b
       <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+      <Command>TlbImp.exe /machine:x86 "$(OutDir)$(TargetName).tlb" /out:"$(OutDir)$(TargetName).dll"
 :: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
 xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1
@@ -168,7 +168,7 @@ xcopy /Y /D "$(OutDir)$(TargetName).dll"  "$(SolutionDir)$(Platform)" || exit /b
       <TypeLibraryName>$(OutDir)$(ProjectName).tlb</TypeLibraryName>
     </Midl>
     <PostBuildEvent>
-      <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:$(OutDir)$(TargetName).dll
+      <Command>TlbImp.exe /machine:x64 "$(OutDir)$(TargetName).tlb" /out:"$(OutDir)$(TargetName).dll"
 :: Copy interface definitions to shared project dir
 xcopy /Y /D "$(IntDir)*.h"  "$(ProjectDir)" || exit /b 1
 xcopy /Y /D "$(IntDir)*.c"  "$(ProjectDir)" || exit /b 1


### PR DESCRIPTION
Fixes issue #170.