### PR TITLE
Clarify meaning of ECG 'duration' in DummyLoader sample code

### DIFF
--- a/DummyLoader/Image3dSource.cpp
+++ b/DummyLoader/Image3dSource.cpp
@@ -12,7 +12,7 @@ Image3dSource::Image3dSource() {
 
     // One second loop starting at t = 10
     const size_t numFrames = 25;
-    const double duration = 1.0; // Seconds
+    const double duration = 1.0; // ECG duration in seconds (the sum of the duration of individual ECG samples)
     const double startTime = 10.0;
 
     {


### PR DESCRIPTION
This change clarifies the meaning of the 'duration' of the DummyLoader ECG. The duration of the ECG is the sum of the durations of each individual ECG sample. Each sample is valid from its sample time until the next ECG sample.

This means that in the generated ECG, the last sample has timestamp 'startTime + duration - delta_time', not 'startTime + duration'