### PR TITLE
Update GetECG documentation to return E_FAIL on missing ECG instead of S_OK

### DIFF
--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -294,7 +294,7 @@ interface IImage3dSource : IUnknown {
     [helpstring("Retrieve color-map table for mapping image intensities to RGBx values. Length is 256.")]
     HRESULT GetColorMap ([out,retval] SAFEARRAY(unsigned int) * map);
 
-    [helpstring("Get ECG data if available [optional]. Shall return S_OK with an empty EcgSeries if EGC is not available.")]
+    [helpstring("Get ECG data if available [optional]. Shall return E_FAIL if EGC is not available.")]
     HRESULT GetECG ([out,retval] EcgSeries * ecg);
 
     [helpstring("")]


### PR DESCRIPTION
The doc string for GetECG previously stated that it should return S_OK with an empty ECG series if ECG is not available. This is problematic because it is unclear what an 'empty ECG Series' mean. What would be the start_time and delta_time of an empty ECG series be? Should the samples and trig_times be zero sized SAFEARRAYs, or should the by set to nullptr? This ambiguity can easily complicate client implementations and result in reliability issues if the client does not handle all situations correctly.

By returning E_FAIL from GetECG when there are no ECG, we avoid this problem. The down-side of this change is that we get failure codes in situations that may be considered normal execution. In .NET clients, error codes are translated into exceptions.