### PR TITLE
Update GetECG documentation to be explicit on the meaning of empty EcgSeries

### DIFF
--- a/Image3dAPI/IImage3d.idl
+++ b/Image3dAPI/IImage3d.idl
@@ -212,7 +212,7 @@ cpp_quote("    double      delta_time = 0;")
 cpp_quote("    SAFEARRAY * samples    = nullptr; ///< float array")
 cpp_quote("    SAFEARRAY * trig_times = nullptr; ///< double array")
 cpp_quote("    ")
-cpp_quote("    /* Primary ctor. */")
+cpp_quote("    /* Primary ctor initializes to empty EcgSeries. */")
 cpp_quote("    EcgSeries() {")
 cpp_quote("    }")
 cpp_quote("    /** Copy ctor. Performs deep copy. */")
@@ -294,7 +294,7 @@ interface IImage3dSource : IUnknown {
     [helpstring("Retrieve color-map table for mapping image intensities to RGBx values. Length is 256.")]
     HRESULT GetColorMap ([out,retval] SAFEARRAY(unsigned int) * map);
 
-    [helpstring("Get ECG data if available [optional]. Shall return S_OK with an empty EcgSeries if EGC is not available.")]
+    [helpstring("Get ECG data if available [optional]. Shall return S_OK with an empty EcgSeries (all struct members set to 0) if EGC is not available")]
     HRESULT GetECG ([out,retval] EcgSeries * ecg);
 
     [helpstring("")]

--- a/TestViewer/MainWindow.xaml.cs
+++ b/TestViewer/MainWindow.xaml.cs
@@ -203,7 +203,7 @@ namespace TestViewer
             try {
                 ecg = m_source.GetECG();
 
-                if (ecg.samples.Length == 0) {
+                if (ecg.samples == null) {
                     ECG.Data = null; // ECG not available
                     return;
                 }


### PR DESCRIPTION
The definition of an empty EcgSeries is that all struct members are default constructed, meaning that start_time and delta_time are set to 0.0, and that samples and trig_times are set to null pointers.

This avoids confusion around the meaning of empty EcgSeries, since this could be interpreted as having a zero size samples array. Now it is clear that an empty EcgSeries has a null pointer samples array.

The extension of this definition is that if the samples array is not null, it should at least contain one element. The same applies to the trig_times array.

Replaces #175