### PR TITLE
DummyLoader: Skip registering the interfaces as part of the loader

### DIFF
--- a/DummyLoader/Main.cpp
+++ b/DummyLoader/Main.cpp
@@ -40,14 +40,13 @@ STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID
 // DllRegisterServer - Adds entries to the system registry.
 STDAPI DllRegisterServer()
 {
-    // registers object, typelib and all interfaces in typelib
-    return _AtlModule.DllRegisterServer(false); // skip TypeLib registration since that is the responsibility of the host
+    return _AtlModule.DllRegisterServer(FALSE); // skip TypeLib registration since that is the responsibility of the host
 }
 
 // DllUnregisterServer - Removes entries from the system registry.
 STDAPI DllUnregisterServer()
 {
-    return _AtlModule.DllUnregisterServer();
+    return _AtlModule.DllUnregisterServer(FALSE);  // skip TypeLib unregistration for consistency with DllRegisterServer 
 }
 
 // DllInstall - Adds/Removes entries to the system registry per user per machine.

--- a/DummyLoader/Main.cpp
+++ b/DummyLoader/Main.cpp
@@ -41,7 +41,7 @@ STDAPI DllGetClassObject(_In_ REFCLSID rclsid, _In_ REFIID riid, _Outptr_ LPVOID
 STDAPI DllRegisterServer()
 {
     // registers object, typelib and all interfaces in typelib
-    return _AtlModule.DllRegisterServer();
+    return _AtlModule.DllRegisterServer(false); // skip TypeLib registration since that is the responsibility of the host
 }
 
 // DllUnregisterServer - Removes entries from the system registry.

--- a/SandboxTest/Main.cpp
+++ b/SandboxTest/Main.cpp
@@ -198,6 +198,21 @@ int wmain(int argc, wchar_t *argv[]) {
         }
     }
 
+    // register type library to enable out-of-proc Image3dAPI calls
+    // only works if running as admin
+    CComPtr<ITypeLib> typelib;
+    HRESULT hr = LoadTypeLibEx(L"Image3dAPI.tlb", REGKIND_REGISTER, &typelib);
+    CHECK(hr);
+
+#if 0
+    // unregister type library
+    TLIBATTR * tlb_attr = nullptr;
+    CHECK(typelib->GetLibAttr(&tlb_attr));
+    hr = UnRegisterTypeLib(tlb_attr->guid, tlb_attr->wMajorVerNum, tlb_attr->wMinorVerNum, tlb_attr->lcid, tlb_attr->syskind);
+    CHECK(hr);
+    typelib->ReleaseTLibAttr(tlb_attr);
+#endif
+
     // create loader in a separate "low integrity" dllhost.exe process
     CComPtr<IImage3dFileLoader> loader;
     CComPtr<IImage3dSource> source;

--- a/TestPython/TestPython.py
+++ b/TestPython/TestPython.py
@@ -1,18 +1,16 @@
 ## Sample code to demonstrate how to access Image3dAPI from a python script
-import platform
 import comtypes
 import comtypes.client
 import numpy as np
 from utils import SafeArrayToNumpy
 from utils import FrameTo3dArray
-from utils import TypeLibFromObject
 
 
 if __name__=="__main__":
     # create loader object
     loader = comtypes.client.CreateObject("DummyLoader.Image3dFileLoader")
     # cast to IImage3dFileLoader interface
-    Image3dAPI = TypeLibFromObject(loader)
+    Image3dAPI = comtypes.client.GetModule("Image3dAPI.tlb")
     loader = loader.QueryInterface(Image3dAPI.IImage3dFileLoader)
 
     # load file

--- a/TestPython/TestPython.pyproj
+++ b/TestPython/TestPython.pyproj
@@ -14,6 +14,7 @@
     <RootNamespace>TestPython</RootNamespace>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
+    <Environment>PATH=$(SolutionDir)x64</Environment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>

--- a/TestPython/utils.py
+++ b/TestPython/utils.py
@@ -1,28 +1,6 @@
 ## Sample code to demonstrate how to access Image3dAPI from a python script
-import platform
 import comtypes
-import comtypes.client
 import numpy as np
-
-
-def TypeLibFromObject (object):
-    """Loads the type library associated with a COM class instance"""
-    import winreg
-
-    with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, "CLSID\\"+object.__clsid+"\\TypeLib", 0, winreg.KEY_READ) as key:
-        typelib = winreg.EnumValue(key, 0)[1]
-    with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, "CLSID\\"+object.__clsid+"\\Version", 0, winreg.KEY_READ) as key:
-        version = winreg.EnumValue(key, 0)[1]
-
-    try:
-        major_ver, minor_ver = version.split(".")
-        return comtypes.client.GetModule([typelib, int(major_ver), int(minor_ver)])
-    except OSError as err:
-        # API 1.2-only compatibility fallback to avoid breaking existing loaders
-        if (version != "1.2") or (err.winerror != -2147319779): # Library not registered
-            raise # rethrow
-        # Fallback to TypeLib version 1.0
-        return comtypes.client.GetModule([typelib, 1, 0])
 
 
 def SafeArrayToNumpy (safearr_ptr, copy=True):


### PR DESCRIPTION
Done to prevent the loader from "hijacking" the registration of the `IImage3dSource` and `IImage3dFileLoader` interfaces that should really be the responsibility of the "host" SW to register.

### How SW implementation suggestion
Host SW that already registers COM classes can just add the IImage3dSource and IImage3dFileLoader to the `library` section of their IDL file to auto-register the interfaces.

Host SW that is _not_ registering any COM classes can instead add the following C++ code:
```
// load and register type library
// only works out-of-proc if running as admin
CComPtr<ITypeLib> pTypeLib;
HRESULT hr = LoadTypeLibEx(L"Image3dAPI.tlb", REGKIND_REGISTER, &pTypeLib);
CHECK(hr);
```
